### PR TITLE
HYDRAN-2092: return empty list instead of 404 from getInvoiceDetails

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>se.sundsvall</groupId>
 	<artifactId>api-service-datawarehousereader</artifactId>
-	<version>5.4</version>
+	<version>5.5</version>
 	<name>api-service-datawarehousereader</name>
 	<description>A single store for fetching data used for tasks such as reporting, visualization and analytics.</description>
 	<properties>

--- a/src/integration-test/java/se/sundsvall/datawarehousereader/apptest/invoices/GetInvoiceDetailsIT.java
+++ b/src/integration-test/java/se/sundsvall/datawarehousereader/apptest/invoices/GetInvoiceDetailsIT.java
@@ -1,7 +1,6 @@
 package se.sundsvall.datawarehousereader.apptest.invoices;
 
 import static org.springframework.http.HttpMethod.GET;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.OK;
 
 import org.junit.jupiter.api.Test;
@@ -36,7 +35,7 @@ class GetInvoiceDetailsIT extends AbstractAppTest {
 		setupCall()
 			.withServicePath(String.format(PATH, "5565027223", "999999999"))
 			.withHttpMethod(GET)
-			.withExpectedResponseStatus(NOT_FOUND)
+			.withExpectedResponseStatus(OK)
 			.withExpectedResponse(RESPONSE_FILE)
 			.sendRequestAndVerifyResponse();
 	}

--- a/src/integration-test/resources/GetInvoiceDetails/__files/test02_getDetailsForNonExistingInvoice/response.json
+++ b/src/integration-test/resources/GetInvoiceDetails/__files/test02_getDetailsForNonExistingInvoice/response.json
@@ -1,5 +1,1 @@
-{
-	"detail": "No invoicedetails found for invoice issuer '5565027223' and invoicenumber '999999999'",
-	"title": "Not Found",
-	"status": 404
-}
+[]

--- a/src/main/java/se/sundsvall/datawarehousereader/api/InvoiceResource.java
+++ b/src/main/java/se/sundsvall/datawarehousereader/api/InvoiceResource.java
@@ -76,7 +76,6 @@ class InvoiceResource {
 	@Operation(summary = "Get invoice details for invoice matching issuer of provided organization number and having invoice number matching provided invoice number", responses = {
 		@ApiResponse(responseCode = "200", description = "Successful operation", useReturnTypeSchema = true),
 		@ApiResponse(responseCode = "400", description = "Bad request", content = @Content(mediaType = APPLICATION_PROBLEM_JSON_VALUE, schema = @Schema(implementation = Problem.class))),
-		@ApiResponse(responseCode = "404", description = "Not found", content = @Content(mediaType = APPLICATION_PROBLEM_JSON_VALUE, schema = @Schema(implementation = Problem.class))),
 		@ApiResponse(responseCode = "500", description = "Internal Server error", content = @Content(mediaType = APPLICATION_PROBLEM_JSON_VALUE, schema = @Schema(implementation = Problem.class)))
 	})
 	ResponseEntity<List<InvoiceDetail>> getInvoiceDetails(

--- a/src/main/java/se/sundsvall/datawarehousereader/service/InvoiceService.java
+++ b/src/main/java/se/sundsvall/datawarehousereader/service/InvoiceService.java
@@ -17,19 +17,15 @@ import se.sundsvall.datawarehousereader.integration.stadsbacken.InvoiceJdbcRepos
 import se.sundsvall.datawarehousereader.integration.stadsbacken.InvoiceRepository;
 import se.sundsvall.datawarehousereader.integration.stadsbacken.model.invoice.InvoiceEntity;
 import se.sundsvall.dept44.models.api.paging.PagingAndSortingMetaData;
-import se.sundsvall.dept44.problem.Problem;
 
 import static java.util.Collections.emptyList;
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.groupingBy;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static se.sundsvall.datawarehousereader.service.mapper.InvoiceMapper.toDetails;
 import static se.sundsvall.datawarehousereader.service.mapper.InvoiceMapper.toInvoices;
 
 @Service
 public class InvoiceService {
-
-	private static final String INVOICE_DETAIL_NOT_FOUND = "No invoicedetails found for invoice issuer '%s' and invoicenumber '%s'";
 
 	private final InvoiceRepository invoiceRepository;
 
@@ -84,11 +80,6 @@ public class InvoiceService {
 	}
 
 	public List<InvoiceDetail> getInvoiceDetails(final String organizationNumber, final long invoiceNumber) {
-		final var entities = invoiceDetailRepository.findAllByOrganizationIdAndInvoiceNumber(organizationNumber, invoiceNumber);
-		if (entities.isEmpty()) {
-			throw Problem.valueOf(NOT_FOUND, String.format(INVOICE_DETAIL_NOT_FOUND, organizationNumber, invoiceNumber));
-		}
-
-		return toDetails(entities);
+		return toDetails(invoiceDetailRepository.findAllByOrganizationIdAndInvoiceNumber(organizationNumber, invoiceNumber));
 	}
 }

--- a/src/test/java/se/sundsvall/datawarehousereader/service/InvoiceServiceTest.java
+++ b/src/test/java/se/sundsvall/datawarehousereader/service/InvoiceServiceTest.java
@@ -25,10 +25,8 @@ import se.sundsvall.datawarehousereader.integration.stadsbacken.InvoiceRepositor
 import se.sundsvall.datawarehousereader.integration.stadsbacken.model.invoice.InvoiceDetailEntity;
 import se.sundsvall.datawarehousereader.integration.stadsbacken.model.invoice.InvoiceEntity;
 import se.sundsvall.datawarehousereader.service.mapper.InvoiceMapper;
-import se.sundsvall.dept44.problem.Problem;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -212,16 +210,15 @@ class InvoiceServiceTest {
 	}
 
 	@Test
-	void getInvoiceDetails_notFound() {
+	void getInvoiceDetails_noMatch() {
 		var organizationNumber = "1234567890";
 		var invoiceNumber = 987654L;
 
 		when(invoiceDetailRepositoryMock.findAllByOrganizationIdAndInvoiceNumber(organizationNumber, invoiceNumber)).thenReturn(List.of());
 
-		assertThatThrownBy(() -> service.getInvoiceDetails(organizationNumber, invoiceNumber))
-			.isInstanceOfAny(Problem.class)
-			.hasMessageContaining(String.format("Not Found: No invoicedetails found for invoice issuer '%s' and invoicenumber '%s'", organizationNumber, invoiceNumber));
+		var result = service.getInvoiceDetails(organizationNumber, invoiceNumber);
 
+		assertThat(result).isEmpty();
 		verify(invoiceDetailRepositoryMock).findAllByOrganizationIdAndInvoiceNumber(organizationNumber, invoiceNumber);
 	}
 

--- a/src/test/resources/api/openapi.yaml
+++ b/src/test/resources/api/openapi.yaml
@@ -5,7 +5,7 @@ info:
   license:
     name: MIT License
     url: https://opensource.org/licenses/MIT
-  version: "5.4"
+  version: "5.5"
 servers:
 - url: http://localhost:53261
   description: Generated server url

--- a/src/test/resources/api/openapi.yaml
+++ b/src/test/resources/api/openapi.yaml
@@ -7,95 +7,95 @@ info:
     url: https://opensource.org/licenses/MIT
   version: "5.4"
 servers:
-  - url: http://localhost:55930
-    description: Generated server url
+- url: http://localhost:53261
+  description: Generated server url
 tags:
-  - name: Measurement
-    description: Measurement operations
-  - name: Installed base
-    description: Installed base operations
-  - name: Agreement
-    description: Agreement operations
-  - name: Customer
-    description: Customer operations
-  - name: Invoice
-    description: Invoice operations
+- name: Measurement
+  description: Measurement operations
+- name: Installed base
+  description: Installed base operations
+- name: Agreement
+  description: Agreement operations
+- name: Customer
+  description: Customer operations
+- name: Invoice
+  description: Invoice operations
 paths:
   /{municipalityId}/measurements/{category}/{aggregateOn}:
     get:
       tags:
-        - Measurement
+      - Measurement
       summary: Get measurement information
       description: Resource returns measurement data matching provided search parameters
       operationId: getMeasurements
       parameters:
-        - name: municipalityId
-          in: path
-          description: Municipality id
-          required: true
-          schema:
-            type: string
-          example: 2281
-        - name: category
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/Category"
-        - name: aggregateOn
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/Aggregation"
-        - name: partyId
-          in: query
+      - name: municipalityId
+        in: path
+        description: Municipality id
+        required: true
+        schema:
+          type: string
+        example: 2281
+      - name: category
+        in: path
+        required: true
+        schema:
+          $ref: "#/components/schemas/Category"
+      - name: aggregateOn
+        in: path
+        required: true
+        schema:
+          $ref: "#/components/schemas/Aggregation"
+      - name: partyId
+        in: query
+        description: PartyId (e.g. a personId or an organizationId)
+        required: false
+        schema:
+          type: string
           description: PartyId (e.g. a personId or an organizationId)
-          required: false
-          schema:
-            type: string
-            description: PartyId (e.g. a personId or an organizationId)
-            examples:
-              - 81471222-5798-11e9-ae24-57fa13b361e1
-        - name: facilityIds
-          in: query
+          examples:
+          - 81471222-5798-11e9-ae24-57fa13b361e1
+      - name: facilityIds
+        in: query
+        description: Facility id (one or more)
+        required: false
+        schema:
+          type: array
           description: Facility id (one or more)
-          required: false
-          schema:
-            type: array
+          examples:
+          - "735999109151401011"
+          items:
+            type: string
             description: Facility id (one or more)
             examples:
-              - "735999109151401011"
-            items:
-              type: string
-              description: Facility id (one or more)
-              examples:
-                - "735999109151401011"
-        - name: fromDateTime
-          in: query
+            - "735999109151401011"
+      - name: fromDateTime
+        in: query
+        description: "Date and time for oldest measurement point to return. Format\
+          \ is yyyy-MM-dd'T'HH:mm:ss.SSSXXX, for example '2000-10-31T01:30:00.000-05:00'"
+        required: false
+        schema:
+          type: string
+          format: date-time
           description: "Date and time for oldest measurement point to return. Format\
-          \ is yyyy-MM-dd'T'HH:mm:ss.SSSXXX, for example '2000-10-31T01:30:00.000-05:00'"
-          required: false
-          schema:
-            type: string
-            format: date-time
-            description: "Date and time for oldest measurement point to return. Format\
             \ is yyyy-MM-dd'T'HH:mm:ss.SSSXXX, for example '2000-10-31T01:30:00.000-05:00'"
-        - name: toDateTime
-          in: query
+      - name: toDateTime
+        in: query
+        description: "Date and time for youngest measurement point to return. Format\
+          \ is yyyy-MM-dd'T'HH:mm:ss.SSSXXX, for example '2000-10-31T01:30:00.000-05:00'"
+        required: false
+        schema:
+          type: string
+          format: date-time
           description: "Date and time for youngest measurement point to return. Format\
-          \ is yyyy-MM-dd'T'HH:mm:ss.SSSXXX, for example '2000-10-31T01:30:00.000-05:00'"
-          required: false
-          schema:
-            type: string
-            format: date-time
-            description: "Date and time for youngest measurement point to return. Format\
             \ is yyyy-MM-dd'T'HH:mm:ss.SSSXXX, for example '2000-10-31T01:30:00.000-05:00'"
-        - name: display
-          in: query
+      - name: display
+        in: query
+        description: Display mode for aggregated series
+        required: false
+        schema:
+          $ref: "#/components/schemas/Display"
           description: Display mode for aggregated series
-          required: false
-          schema:
-            $ref: "#/components/schemas/Display"
-            description: Display mode for aggregated series
       responses:
         "200":
           description: Successful operation
@@ -116,8 +116,8 @@ paths:
             application/problem+json:
               schema:
                 oneOf:
-                  - $ref: "#/components/schemas/Problem"
-                  - $ref: "#/components/schemas/ConstraintViolationProblem"
+                - $ref: "#/components/schemas/Problem"
+                - $ref: "#/components/schemas/ConstraintViolationProblem"
         "500":
           description: Internal Server error
           content:
@@ -127,202 +127,202 @@ paths:
   /{municipalityId}/invoices:
     get:
       tags:
-        - Invoice
+      - Invoice
       summary: Get basic invoice information
       description: Resource returns all invoices matching provided search parameters
       operationId: getInvoices
       parameters:
-        - name: municipalityId
-          in: path
-          description: Municipality id
-          required: true
-          schema:
+      - name: municipalityId
+        in: path
+        description: Municipality id
+        required: true
+        schema:
+          type: string
+        example: 2281
+      - name: customerNumber
+        in: query
+        required: false
+        schema:
+          type: array
+          items:
             type: string
-          example: 2281
-        - name: customerNumber
-          in: query
-          required: false
-          schema:
-            type: array
-            items:
-              type: string
-              description: Customer numbers
-              examples:
-                - "39195"
-        - name: customerType
-          in: query
-          required: false
-          schema:
-            $ref: "#/components/schemas/CustomerType"
-        - name: facilityIds
-          in: query
-          required: false
-          schema:
-            type: array
-            items:
-              type: string
-              description: Facility ids
-              examples:
-                - "735999109151401011"
-        - name: invoiceNumber
-          in: query
+            description: Customer numbers
+            examples:
+            - "39195"
+      - name: customerType
+        in: query
+        required: false
+        schema:
+          $ref: "#/components/schemas/CustomerType"
+      - name: facilityIds
+        in: query
+        required: false
+        schema:
+          type: array
+          items:
+            type: string
+            description: Facility ids
+            examples:
+            - "735999109151401011"
+      - name: invoiceNumber
+        in: query
+        description: Invoice number
+        required: false
+        schema:
+          type: integer
+          format: int64
           description: Invoice number
-          required: false
-          schema:
-            type: integer
-            format: int64
-            description: Invoice number
-            examples:
-              - "767915994"
-        - name: invoiceDateFrom
-          in: query
+          examples:
+          - "767915994"
+      - name: invoiceDateFrom
+        in: query
+        description: Earliest invoice date. Format is YYYY-MM-DD.
+        required: false
+        schema:
+          type: string
+          format: date
           description: Earliest invoice date. Format is YYYY-MM-DD.
-          required: false
-          schema:
-            type: string
-            format: date
-            description: Earliest invoice date. Format is YYYY-MM-DD.
-            examples:
-              - 2022-01-01
-        - name: invoiceDateTo
-          in: query
+          examples:
+          - 2022-01-01
+      - name: invoiceDateTo
+        in: query
+        description: Latest invoice date. Format is YYYY-MM-DD.
+        required: false
+        schema:
+          type: string
+          format: date
           description: Latest invoice date. Format is YYYY-MM-DD.
-          required: false
-          schema:
-            type: string
-            format: date
-            description: Latest invoice date. Format is YYYY-MM-DD.
-            examples:
-              - 2022-01-31
-        - name: invoiceName
-          in: query
+          examples:
+          - 2022-01-31
+      - name: invoiceName
+        in: query
+        description: Invoice name
+        required: false
+        schema:
+          type: string
           description: Invoice name
-          required: false
-          schema:
-            type: string
-            description: Invoice name
-            examples:
-              - 765801493.pdf
-        - name: invoiceType
-          in: query
+          examples:
+          - 765801493.pdf
+      - name: invoiceType
+        in: query
+        description: Invoice type
+        required: false
+        schema:
+          type: string
           description: Invoice type
-          required: false
-          schema:
-            type: string
-            description: Invoice type
-            examples:
-              - Faktura
-        - name: invoiceStatus
-          in: query
+          examples:
+          - Faktura
+      - name: invoiceStatus
+        in: query
+        description: Invoice status
+        required: false
+        schema:
+          type: string
           description: Invoice status
-          required: false
-          schema:
-            type: string
-            description: Invoice status
-            examples:
-              - Skickad
-        - name: ocrNumber
-          in: query
+          examples:
+          - Skickad
+      - name: ocrNumber
+        in: query
+        description: OCR number
+        required: false
+        schema:
+          type: integer
+          format: int64
           description: OCR number
-          required: false
-          schema:
-            type: integer
-            format: int64
-            description: OCR number
-            examples:
-              - "767915994"
-        - name: dueDateFrom
-          in: query
+          examples:
+          - "767915994"
+      - name: dueDateFrom
+        in: query
+        description: Earliest due date. Format is YYYY-MM-DD.
+        required: false
+        schema:
+          type: string
+          format: date
           description: Earliest due date. Format is YYYY-MM-DD.
-          required: false
-          schema:
-            type: string
-            format: date
-            description: Earliest due date. Format is YYYY-MM-DD.
-            examples:
-              - 2022-01-01
-        - name: dueDateTo
-          in: query
+          examples:
+          - 2022-01-01
+      - name: dueDateTo
+        in: query
+        description: Latest due date. Format is YYYY-MM-DD.
+        required: false
+        schema:
+          type: string
+          format: date
           description: Latest due date. Format is YYYY-MM-DD.
-          required: false
-          schema:
-            type: string
-            format: date
-            description: Latest due date. Format is YYYY-MM-DD.
-            examples:
-              - 2022-01-31
-        - name: organizationGroup
-          in: query
+          examples:
+          - 2022-01-31
+      - name: organizationGroup
+        in: query
+        description: Organization group
+        required: false
+        schema:
+          type: string
           description: Organization group
-          required: false
-          schema:
-            type: string
-            description: Organization group
-            examples:
-              - stadsbacken
-        - name: organizationNumbers
-          in: query
+          examples:
+          - stadsbacken
+      - name: organizationNumbers
+        in: query
+        description: Organization number of invoice issuer
+        required: false
+        schema:
+          type: array
           description: Organization number of invoice issuer
-          required: false
-          schema:
-            type: array
+          examples:
+          - "5565027223"
+          items:
+            type: string
             description: Organization number of invoice issuer
             examples:
-              - "5565027223"
-            items:
-              type: string
-              description: Organization number of invoice issuer
-              examples:
-                - "5565027223"
-        - name: administration
-          in: query
+            - "5565027223"
+      - name: administration
+        in: query
+        description: Administration
+        required: false
+        schema:
+          type: string
           description: Administration
-          required: false
-          schema:
+          examples:
+          - Sundsvall Elnät
+      - name: sortBy
+        in: query
+        required: false
+        schema:
+          type: array
+          items:
             type: string
-            description: Administration
+            description: The properties to sort on
             examples:
-              - Sundsvall Elnät
-        - name: sortBy
-          in: query
-          required: false
-          schema:
-            type: array
-            items:
-              type: string
-              description: The properties to sort on
-              examples:
-                - propertyName
-        - name: sortDirection
-          in: query
-          description: The sort order direction
-          required: false
-          schema:
-            $ref: "#/components/schemas/Direction"
-        - name: page
-          in: query
+            - propertyName
+      - name: sortDirection
+        in: query
+        description: The sort order direction
+        required: false
+        schema:
+          $ref: "#/components/schemas/Direction"
+      - name: page
+        in: query
+        description: Page number
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 1
           description: Page number
-          required: false
-          schema:
-            type: integer
-            format: int32
-            default: 1
-            description: Page number
-            examples:
-              - "1"
-            minimum: 1
-        - name: limit
-          in: query
-          description: Result size per page. Maximum allowed value is dynamically configured
-          required: false
-          schema:
-            type: integer
-            format: int32
-            description: Result size per page. Maximum allowed value is dynamically
-              configured
-            examples:
-              - "15"
-            minimum: 1
+          examples:
+          - "1"
+          minimum: 1
+      - name: limit
+        in: query
+        description: Result size per page. Maximum allowed value is dynamically configured
+        required: false
+        schema:
+          type: integer
+          format: int32
+          description: Result size per page. Maximum allowed value is dynamically
+            configured
+          examples:
+          - "15"
+          minimum: 1
       responses:
         "200":
           description: Successful operation
@@ -336,8 +336,8 @@ paths:
             application/problem+json:
               schema:
                 oneOf:
-                  - $ref: "#/components/schemas/Problem"
-                  - $ref: "#/components/schemas/ConstraintViolationProblem"
+                - $ref: "#/components/schemas/Problem"
+                - $ref: "#/components/schemas/ConstraintViolationProblem"
         "500":
           description: Internal Server error
           content:
@@ -347,33 +347,33 @@ paths:
   /{municipalityId}/invoices/{organizationNumber}/{invoiceNumber}/details:
     get:
       tags:
-        - Invoice
+      - Invoice
       summary: Get invoice details for invoice matching issuer of provided organization
         number and having invoice number matching provided invoice number
       operationId: getInvoiceDetails
       parameters:
-        - name: municipalityId
-          in: path
-          description: Municipality id
-          required: true
-          schema:
-            type: string
-          example: 2281
-        - name: organizationNumber
-          in: path
-          description: Organization number of invoice issuer
-          required: true
-          schema:
-            type: string
-          example: 5565027223
-        - name: invoiceNumber
-          in: path
-          description: Invoice number
-          required: true
-          schema:
-            type: integer
-            format: int64
-          example: 805137494
+      - name: municipalityId
+        in: path
+        description: Municipality id
+        required: true
+        schema:
+          type: string
+        example: 2281
+      - name: organizationNumber
+        in: path
+        description: Organization number of invoice issuer
+        required: true
+        schema:
+          type: string
+        example: 5565027223
+      - name: invoiceNumber
+        in: path
+        description: Invoice number
+        required: true
+        schema:
+          type: integer
+          format: int64
+        example: 805137494
       responses:
         "200":
           description: Successful operation
@@ -389,12 +389,6 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/Problem"
-        "404":
-          description: Not found
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/Problem"
         "500":
           description: Internal Server error
           content:
@@ -404,94 +398,94 @@ paths:
   /{municipalityId}/invoices/customers/{customerNumber}:
     get:
       tags:
-        - Invoice
+      - Invoice
       summary: Get invoices for a customer
       description: "Resource returns invoices matching the given customer number,\
         \ optionally filtered by organization and invoice period"
       operationId: getInvoicesForCustomer
       parameters:
-        - name: municipalityId
-          in: path
-          description: Municipality id
-          required: true
-          schema:
+      - name: municipalityId
+        in: path
+        description: Municipality id
+        required: true
+        schema:
+          type: string
+        example: 2281
+      - name: customerNumber
+        in: path
+        description: Customer number
+        required: true
+        schema:
+          type: string
+        example: 216870
+      - name: organizationIds
+        in: query
+        required: false
+        schema:
+          type: array
+          items:
             type: string
-          example: 2281
-        - name: customerNumber
-          in: path
-          description: Customer number
-          required: true
-          schema:
-            type: string
-          example: 216870
-        - name: organizationIds
-          in: query
-          required: false
-          schema:
-            type: array
-            items:
-              type: string
-              description: Organization id of invoice issuer
-              examples:
-                - "5565027223"
-        - name: periodFrom
-          in: query
+            description: Organization id of invoice issuer
+            examples:
+            - "5565027223"
+      - name: periodFrom
+        in: query
+        description: Earliest invoice period start. Format is YYYY-MM-DD.
+        required: false
+        schema:
+          type: string
+          format: date
           description: Earliest invoice period start. Format is YYYY-MM-DD.
-          required: false
-          schema:
-            type: string
-            format: date
-            description: Earliest invoice period start. Format is YYYY-MM-DD.
-            examples:
-              - 2025-01-01
-        - name: periodTo
-          in: query
+          examples:
+          - 2025-01-01
+      - name: periodTo
+        in: query
+        description: Latest invoice period end. Format is YYYY-MM-DD.
+        required: false
+        schema:
+          type: string
+          format: date
           description: Latest invoice period end. Format is YYYY-MM-DD.
-          required: false
-          schema:
-            type: string
-            format: date
-            description: Latest invoice period end. Format is YYYY-MM-DD.
-            examples:
-              - 2025-12-31
-        - name: sortBy
-          in: query
+          examples:
+          - 2025-12-31
+      - name: sortBy
+        in: query
+        description: Column to sort by.
+        required: false
+        schema:
+          type: string
           description: Column to sort by.
-          required: false
-          schema:
-            type: string
-            description: Column to sort by.
-            examples:
-              - periodFrom
-              - periodTo
-              - InvoiceDate
-              - DueDate
-              - InvoiceNumber
-              - TotalAmount
-        - name: page
-          in: query
+          examples:
+          - periodFrom
+          - periodTo
+          - InvoiceDate
+          - DueDate
+          - InvoiceNumber
+          - TotalAmount
+      - name: page
+        in: query
+        description: Page number
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 1
           description: Page number
-          required: false
-          schema:
-            type: integer
-            format: int32
-            default: 1
-            description: Page number
-            examples:
-              - "1"
-            minimum: 1
-        - name: limit
-          in: query
-          description: Result size per page. Maximum allowed value is dynamically configured
-          required: false
-          schema:
-            type: integer
-            format: int32
-            description: Result size per page. Maximum allowed value is dynamically
-              configured
-            examples:
-              - "15"
-            minimum: 1
+          examples:
+          - "1"
+          minimum: 1
+      - name: limit
+        in: query
+        description: Result size per page. Maximum allowed value is dynamically configured
+        required: false
+        schema:
+          type: integer
+          format: int32
+          description: Result size per page. Maximum allowed value is dynamically
+            configured
+          examples:
+          - "15"
+          minimum: 1
       responses:
         "200":
           description: Successful operation
@@ -505,8 +499,8 @@ paths:
             application/problem+json:
               schema:
                 oneOf:
-                  - $ref: "#/components/schemas/Problem"
-                  - $ref: "#/components/schemas/ConstraintViolationProblem"
+                - $ref: "#/components/schemas/Problem"
+                - $ref: "#/components/schemas/ConstraintViolationProblem"
         "500":
           description: Internal Server error
           content:
@@ -516,159 +510,159 @@ paths:
   /{municipalityId}/installedbase:
     get:
       tags:
-        - Installed base
+      - Installed base
       summary: Get installed base information
       description: Resource returns all installed bases matching provided search parameters
       operationId: getInstalledBase
       parameters:
-        - name: municipalityId
-          in: path
-          description: Municipality id
-          required: true
-          schema:
-            type: string
-          example: 2281
-        - name: company
-          in: query
+      - name: municipalityId
+        in: path
+        description: Municipality id
+        required: true
+        schema:
+          type: string
+        example: 2281
+      - name: company
+        in: query
+        description: Company
+        required: false
+        schema:
+          type: string
           description: Company
-          required: false
-          schema:
-            type: string
-            description: Company
-            examples:
-              - Sundsvall Energi AB
-        - name: customerNumber
-          in: query
+          examples:
+          - Sundsvall Energi AB
+      - name: customerNumber
+        in: query
+        description: Customer number
+        required: false
+        schema:
+          type: string
           description: Customer number
-          required: false
-          schema:
-            type: string
-            description: Customer number
-            examples:
-              - "104327"
-        - name: type
-          in: query
+          examples:
+          - "104327"
+      - name: type
+        in: query
+        description: Type
+        required: false
+        schema:
+          type: string
           description: Type
-          required: false
-          schema:
-            type: string
-            description: Type
-            examples:
-              - Fjärrvärme
-        - name: facilityId
-          in: query
+          examples:
+          - Fjärrvärme
+      - name: facilityId
+        in: query
+        description: Facility id
+        required: false
+        schema:
+          type: string
           description: Facility id
-          required: false
-          schema:
-            type: string
-            description: Facility id
-            examples:
-              - "735999109270751042"
-        - name: careOf
-          in: query
+          examples:
+          - "735999109270751042"
+      - name: careOf
+        in: query
+        description: Care of address
+        required: false
+        schema:
+          type: string
           description: Care of address
-          required: false
-          schema:
-            type: string
-            description: Care of address
-            examples:
-              - Agatha Malm
-        - name: street
-          in: query
+          examples:
+          - Agatha Malm
+      - name: street
+        in: query
+        description: Street
+        required: false
+        schema:
+          type: string
           description: Street
-          required: false
-          schema:
-            type: string
-            description: Street
-            examples:
-              - Storgatan 9
-        - name: postCode
-          in: query
+          examples:
+          - Storgatan 9
+      - name: postCode
+        in: query
+        description: Postal code
+        required: false
+        schema:
+          type: string
           description: Postal code
-          required: false
-          schema:
-            type: string
-            description: Postal code
-            examples:
-              - "85230"
-        - name: city
-          in: query
+          examples:
+          - "85230"
+      - name: city
+        in: query
+        description: City
+        required: false
+        schema:
+          type: string
           description: City
-          required: false
-          schema:
-            type: string
-            description: City
-            examples:
-              - Sundsvall
-        - name: propertyDesignation
-          in: query
+          examples:
+          - Sundsvall
+      - name: propertyDesignation
+        in: query
+        description: Property designation
+        required: false
+        schema:
+          type: string
           description: Property designation
-          required: false
-          schema:
-            type: string
-            description: Property designation
-            examples:
-              - Södermalm 1:27
-        - name: lastModifiedDateFrom
-          in: query
+          examples:
+          - Södermalm 1:27
+      - name: lastModifiedDateFrom
+        in: query
+        description: Earliest date when item was last modified
+        required: false
+        schema:
+          type: string
+          format: date
           description: Earliest date when item was last modified
-          required: false
-          schema:
-            type: string
-            format: date
-            description: Earliest date when item was last modified
-            examples:
-              - 2022-12-31
-        - name: lastModifiedDateTom
-          in: query
+          examples:
+          - 2022-12-31
+      - name: lastModifiedDateTom
+        in: query
+        description: Latest date when item was last modified
+        required: false
+        schema:
+          type: string
+          format: date
           description: Latest date when item was last modified
-          required: false
-          schema:
+          examples:
+          - 2022-12-31
+      - name: sortBy
+        in: query
+        required: false
+        schema:
+          type: array
+          items:
             type: string
-            format: date
-            description: Latest date when item was last modified
+            description: The properties to sort on
             examples:
-              - 2022-12-31
-        - name: sortBy
-          in: query
-          required: false
-          schema:
-            type: array
-            items:
-              type: string
-              description: The properties to sort on
-              examples:
-                - propertyName
-        - name: sortDirection
-          in: query
-          description: The sort order direction
-          required: false
-          schema:
-            $ref: "#/components/schemas/Direction"
-        - name: page
-          in: query
+            - propertyName
+      - name: sortDirection
+        in: query
+        description: The sort order direction
+        required: false
+        schema:
+          $ref: "#/components/schemas/Direction"
+      - name: page
+        in: query
+        description: Page number
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 1
           description: Page number
-          required: false
-          schema:
-            type: integer
-            format: int32
-            default: 1
-            description: Page number
-            examples:
-              - "1"
-            minimum: 1
-        - name: limit
-          in: query
-          description: Result size per page. Maximum allowed value is dynamically configured
-          required: false
-          schema:
-            type: integer
-            format: int32
-            description: Result size per page. Maximum allowed value is dynamically
-              configured
-            examples:
-              - "15"
-            minimum: 1
+          examples:
+          - "1"
+          minimum: 1
+      - name: limit
+        in: query
+        description: Result size per page. Maximum allowed value is dynamically configured
+        required: false
+        schema:
+          type: integer
+          format: int32
+          description: Result size per page. Maximum allowed value is dynamically
+            configured
+          examples:
+          - "15"
+          minimum: 1
       responses:
         "200":
           description: Successful operation
@@ -682,8 +676,8 @@ paths:
             application/problem+json:
               schema:
                 oneOf:
-                  - $ref: "#/components/schemas/Problem"
-                  - $ref: "#/components/schemas/ConstraintViolationProblem"
+                - $ref: "#/components/schemas/Problem"
+                - $ref: "#/components/schemas/ConstraintViolationProblem"
         "500":
           description: Internal Server error
           content:
@@ -694,77 +688,77 @@ paths:
   /{municipalityId}/installedbase/{partyId}:
     get:
       tags:
-        - Installed base
+      - Installed base
       summary: Get installed base information by party id
       description: Resource returns installed bases for the given party id
       operationId: getInstalledBaseByPartyId
       parameters:
-        - name: municipalityId
-          in: path
-          description: Municipality id
-          required: true
-          schema:
-            type: string
-          example: 2281
-        - name: partyId
-          in: path
-          description: Party id (UUID)
-          required: true
-          schema:
-            type: string
-          example: 898B3634-A2F9-483C-8808-37F3F25CF24E
-        - name: organizationIds
-          in: query
+      - name: municipalityId
+        in: path
+        description: Municipality id
+        required: true
+        schema:
+          type: string
+        example: 2281
+      - name: partyId
+        in: path
+        description: Party id (UUID)
+        required: true
+        schema:
+          type: string
+        example: 898B3634-A2F9-483C-8808-37F3F25CF24E
+      - name: organizationIds
+        in: query
+        description: Comma-separated list of organization ids
+        required: false
+        schema:
+          type: string
           description: Comma-separated list of organization ids
-          required: false
-          schema:
-            type: string
-            description: Comma-separated list of organization ids
-            examples:
-              - "123456789,123456987"
-        - name: date
-          in: query
+          examples:
+          - "123456789,123456987"
+      - name: date
+        in: query
+        description: Filter date
+        required: false
+        schema:
+          type: string
+          format: date
           description: Filter date
-          required: false
-          schema:
-            type: string
-            format: date
-            description: Filter date
-            examples:
-              - 2025-06-01
-        - name: sortBy
-          in: query
+          examples:
+          - 2025-06-01
+      - name: sortBy
+        in: query
+        description: Column to sort by
+        required: false
+        schema:
+          type: string
           description: Column to sort by
-          required: false
-          schema:
-            type: string
-            description: Column to sort by
-            examples:
-              - Company
-        - name: page
-          in: query
+          examples:
+          - Company
+      - name: page
+        in: query
+        description: Page number
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 1
           description: Page number
-          required: false
-          schema:
-            type: integer
-            format: int32
-            default: 1
-            description: Page number
-            examples:
-              - "1"
-            minimum: 1
-        - name: limit
-          in: query
-          description: Result size per page. Maximum allowed value is dynamically configured
-          required: false
-          schema:
-            type: integer
-            format: int32
-            description: Result size per page. Maximum allowed value is dynamically
-              configured
-            examples:
-              - "15"
-            minimum: 1
+          examples:
+          - "1"
+          minimum: 1
+      - name: limit
+        in: query
+        description: Result size per page. Maximum allowed value is dynamically configured
+        required: false
+        schema:
+          type: integer
+          format: int32
+          description: Result size per page. Maximum allowed value is dynamically
+            configured
+          examples:
+          - "15"
+          minimum: 1
       responses:
         "200":
           description: Successful operation
@@ -778,8 +772,8 @@ paths:
             application/problem+json:
               schema:
                 oneOf:
-                  - $ref: "#/components/schemas/Problem"
-                  - $ref: "#/components/schemas/ConstraintViolationProblem"
+                - $ref: "#/components/schemas/Problem"
+                - $ref: "#/components/schemas/ConstraintViolationProblem"
         "500":
           description: Internal Server error
           content:
@@ -789,105 +783,105 @@ paths:
   /{municipalityId}/installations:
     get:
       tags:
-        - Installations
+      - Installations
       summary: Get installation details
       description: Resource returns all installations matching provided search parameters
       operationId: getInstallationDetails
       parameters:
-        - name: municipalityId
-          in: path
-          description: Municipality id
-          required: true
-          schema:
-            type: string
-          example: 2281
-        - name: installed
-          in: query
+      - name: municipalityId
+        in: path
+        description: Municipality id
+        required: true
+        schema:
+          type: string
+        example: 2281
+      - name: installed
+        in: query
+        description: Is the installation installed
+        required: false
+        schema:
+          type: boolean
           description: Is the installation installed
-          required: false
-          schema:
-            type: boolean
-            description: Is the installation installed
-            examples:
-              - "true"
-        - name: lastModifiedDateFrom
-          in: query
+          examples:
+          - "true"
+      - name: lastModifiedDateFrom
+        in: query
+        description: Earliest date when item was last modified
+        required: false
+        schema:
+          type: string
+          format: date
           description: Earliest date when item was last modified
-          required: false
-          schema:
-            type: string
-            format: date
-            description: Earliest date when item was last modified
-            examples:
-              - 2022-12-31
-        - name: lastModifiedDateTo
-          in: query
+          examples:
+          - 2022-12-31
+      - name: lastModifiedDateTo
+        in: query
+        description: Latest date when item was last modified
+        required: false
+        schema:
+          type: string
+          format: date
           description: Latest date when item was last modified
-          required: false
-          schema:
-            type: string
-            format: date
-            description: Latest date when item was last modified
-            examples:
-              - 2022-12-31
-        - name: category
-          in: query
+          examples:
+          - 2022-12-31
+      - name: category
+        in: query
+        description: Category
+        required: false
+        schema:
+          $ref: "#/components/schemas/Category"
           description: Category
-          required: false
-          schema:
-            $ref: "#/components/schemas/Category"
-            description: Category
-            examples:
-              - ELECTRICITY
-        - name: facilityId
-          in: query
+          examples:
+          - ELECTRICITY
+      - name: facilityId
+        in: query
+        description: Facility id
+        required: false
+        schema:
+          type: string
           description: Facility id
-          required: false
-          schema:
+          examples:
+          - "735999109151401011"
+      - name: sortBy
+        in: query
+        required: false
+        schema:
+          type: array
+          items:
             type: string
-            description: Facility id
+            description: The properties to sort on
             examples:
-              - "735999109151401011"
-        - name: sortBy
-          in: query
-          required: false
-          schema:
-            type: array
-            items:
-              type: string
-              description: The properties to sort on
-              examples:
-                - propertyName
-        - name: sortDirection
-          in: query
-          description: The sort order direction
-          required: false
-          schema:
-            $ref: "#/components/schemas/Direction"
-        - name: page
-          in: query
+            - propertyName
+      - name: sortDirection
+        in: query
+        description: The sort order direction
+        required: false
+        schema:
+          $ref: "#/components/schemas/Direction"
+      - name: page
+        in: query
+        description: Page number
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 1
           description: Page number
-          required: false
-          schema:
-            type: integer
-            format: int32
-            default: 1
-            description: Page number
-            examples:
-              - "1"
-            minimum: 1
-        - name: limit
-          in: query
-          description: Result size per page. Maximum allowed value is dynamically configured
-          required: false
-          schema:
-            type: integer
-            format: int32
-            description: Result size per page. Maximum allowed value is dynamically
-              configured
-            examples:
-              - "15"
-            minimum: 1
+          examples:
+          - "1"
+          minimum: 1
+      - name: limit
+        in: query
+        description: Result size per page. Maximum allowed value is dynamically configured
+        required: false
+        schema:
+          type: integer
+          format: int32
+          description: Result size per page. Maximum allowed value is dynamically
+            configured
+          examples:
+          - "15"
+          minimum: 1
       responses:
         "200":
           description: Successful operation
@@ -901,8 +895,8 @@ paths:
             application/problem+json:
               schema:
                 oneOf:
-                  - $ref: "#/components/schemas/Problem"
-                  - $ref: "#/components/schemas/ConstraintViolationProblem"
+                - $ref: "#/components/schemas/Problem"
+                - $ref: "#/components/schemas/ConstraintViolationProblem"
         "500":
           description: Internal Server error
           content:
@@ -912,96 +906,96 @@ paths:
   /{municipalityId}/customer/engagements:
     get:
       tags:
-        - Customer
+      - Customer
       summary: Get basic customer information
       description: Resource returns all customer engagements matching provided search
         parameters
       operationId: getCustomerEngagements
       parameters:
-        - name: municipalityId
-          in: path
-          description: Municipality id
-          required: true
-          schema:
+      - name: municipalityId
+        in: path
+        description: Municipality id
+        required: true
+        schema:
+          type: string
+        example: 2281
+      - name: partyId
+        in: query
+        required: false
+        schema:
+          type: array
+          items:
             type: string
-          example: 2281
-        - name: partyId
-          in: query
-          required: false
-          schema:
-            type: array
-            items:
-              type: string
-              description: PartyId (e.g. a personId or an organizationId)
-              examples:
-                - 81471222-5798-11e9-ae24-57fa13b361e1
-        - name: customerNumber
-          in: query
+            description: PartyId (e.g. a personId or an organizationId)
+            examples:
+            - 81471222-5798-11e9-ae24-57fa13b361e1
+      - name: customerNumber
+        in: query
+        description: Customer number
+        required: false
+        schema:
+          type: string
           description: Customer number
-          required: false
-          schema:
-            type: string
-            description: Customer number
-            examples:
-              - "10007"
-        - name: organizationNumber
-          in: query
+          examples:
+          - "10007"
+      - name: organizationNumber
+        in: query
+        description: Organization number for counterpart of engagement
+        required: false
+        schema:
+          type: string
           description: Organization number for counterpart of engagement
-          required: false
-          schema:
-            type: string
-            description: Organization number for counterpart of engagement
-            examples:
-              - "5565027223"
-        - name: organizationName
-          in: query
+          examples:
+          - "5565027223"
+      - name: organizationName
+        in: query
+        description: Organization name for counterpart of engagement
+        required: false
+        schema:
+          type: string
           description: Organization name for counterpart of engagement
-          required: false
-          schema:
+          examples:
+          - Sundsvall Elnät
+      - name: sortBy
+        in: query
+        required: false
+        schema:
+          type: array
+          items:
             type: string
-            description: Organization name for counterpart of engagement
+            description: The properties to sort on
             examples:
-              - Sundsvall Elnät
-        - name: sortBy
-          in: query
-          required: false
-          schema:
-            type: array
-            items:
-              type: string
-              description: The properties to sort on
-              examples:
-                - propertyName
-        - name: sortDirection
-          in: query
-          description: The sort order direction
-          required: false
-          schema:
-            $ref: "#/components/schemas/Direction"
-        - name: page
-          in: query
+            - propertyName
+      - name: sortDirection
+        in: query
+        description: The sort order direction
+        required: false
+        schema:
+          $ref: "#/components/schemas/Direction"
+      - name: page
+        in: query
+        description: Page number
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 1
           description: Page number
-          required: false
-          schema:
-            type: integer
-            format: int32
-            default: 1
-            description: Page number
-            examples:
-              - "1"
-            minimum: 1
-        - name: limit
-          in: query
-          description: Result size per page. Maximum allowed value is dynamically configured
-          required: false
-          schema:
-            type: integer
-            format: int32
-            description: Result size per page. Maximum allowed value is dynamically
-              configured
-            examples:
-              - "15"
-            minimum: 1
+          examples:
+          - "1"
+          minimum: 1
+      - name: limit
+        in: query
+        description: Result size per page. Maximum allowed value is dynamically configured
+        required: false
+        schema:
+          type: integer
+          format: int32
+          description: Result size per page. Maximum allowed value is dynamically
+            configured
+          examples:
+          - "15"
+          minimum: 1
       responses:
         "200":
           description: Successful operation
@@ -1015,8 +1009,8 @@ paths:
             application/problem+json:
               schema:
                 oneOf:
-                  - $ref: "#/components/schemas/Problem"
-                  - $ref: "#/components/schemas/ConstraintViolationProblem"
+                - $ref: "#/components/schemas/Problem"
+                - $ref: "#/components/schemas/ConstraintViolationProblem"
         "500":
           description: Internal Server error
           content:
@@ -1026,92 +1020,92 @@ paths:
   /{municipalityId}/customer/details:
     get:
       tags:
-        - Customer
+      - Customer
       summary: Get detailed customer information
       description: Resource returns all customer details matching provided search
         parameters
       operationId: getCustomerDetails
       parameters:
-        - name: municipalityId
-          in: path
-          description: Municipality id
-          required: true
-          schema:
+      - name: municipalityId
+        in: path
+        description: Municipality id
+        required: true
+        schema:
+          type: string
+        example: 2281
+      - name: partyId
+        in: query
+        required: false
+        schema:
+          type: array
+          items:
             type: string
-          example: 2281
-        - name: partyId
-          in: query
-          required: false
-          schema:
-            type: array
-            items:
-              type: string
-              description: PartyId (e.g. a personId or an organizationId)
-              examples:
-                - 81471222-5798-11e9-ae24-57fa13b361e1
-        - name: customerEngagementOrgId
-          in: query
+            description: PartyId (e.g. a personId or an organizationId)
+            examples:
+            - 81471222-5798-11e9-ae24-57fa13b361e1
+      - name: customerEngagementOrgId
+        in: query
+        description: Organization id for customer engagements
+        required: true
+        schema:
+          type: string
           description: Organization id for customer engagements
-          required: true
-          schema:
-            type: string
-            description: Organization id for customer engagements
-            examples:
-              - "5565027225"
-        - name: fromDateTime
-          in: query
+          examples:
+          - "5565027225"
+      - name: fromDateTime
+        in: query
+        description: Date and time for when to search for changes from. Format is
+          yyyy-MM-dd'T'HH:mm:ss.SSSXXX. If omitted changes within the last year will
+          be returned.
+        required: false
+        schema:
+          type: string
+          format: date-time
           description: Date and time for when to search for changes from. Format is
-            yyyy-MM-dd'T'HH:mm:ss.SSSXXX. If omitted changes within the last year will
-            be returned.
-          required: false
-          schema:
+            yyyy-MM-dd'T'HH:mm:ss.SSSXXX. If omitted changes within the last year
+            will be returned.
+          examples:
+          - 2000-10-31T01:30:00.000-05:00
+      - name: sortBy
+        in: query
+        required: false
+        schema:
+          type: array
+          items:
             type: string
-            format: date-time
-            description: Date and time for when to search for changes from. Format is
-              yyyy-MM-dd'T'HH:mm:ss.SSSXXX. If omitted changes within the last year
-              will be returned.
+            description: The properties to sort on
             examples:
-              - 2000-10-31T01:30:00.000-05:00
-        - name: sortBy
-          in: query
-          required: false
-          schema:
-            type: array
-            items:
-              type: string
-              description: The properties to sort on
-              examples:
-                - propertyName
-        - name: sortDirection
-          in: query
-          description: The sort order direction
-          required: false
-          schema:
-            $ref: "#/components/schemas/Direction"
-        - name: page
-          in: query
+            - propertyName
+      - name: sortDirection
+        in: query
+        description: The sort order direction
+        required: false
+        schema:
+          $ref: "#/components/schemas/Direction"
+      - name: page
+        in: query
+        description: Page number
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 1
           description: Page number
-          required: false
-          schema:
-            type: integer
-            format: int32
-            default: 1
-            description: Page number
-            examples:
-              - "1"
-            minimum: 1
-        - name: limit
-          in: query
-          description: Result size per page. Maximum allowed value is dynamically configured
-          required: false
-          schema:
-            type: integer
-            format: int32
-            description: Result size per page. Maximum allowed value is dynamically
-              configured
-            examples:
-              - "15"
-            minimum: 1
+          examples:
+          - "1"
+          minimum: 1
+      - name: limit
+        in: query
+        description: Result size per page. Maximum allowed value is dynamically configured
+        required: false
+        schema:
+          type: integer
+          format: int32
+          description: Result size per page. Maximum allowed value is dynamically
+            configured
+          examples:
+          - "15"
+          minimum: 1
       responses:
         "200":
           description: Successful operation
@@ -1125,8 +1119,8 @@ paths:
             application/problem+json:
               schema:
                 oneOf:
-                  - $ref: "#/components/schemas/Problem"
-                  - $ref: "#/components/schemas/ConstraintViolationProblem"
+                - $ref: "#/components/schemas/Problem"
+                - $ref: "#/components/schemas/ConstraintViolationProblem"
         "500":
           description: Internal Server error
           content:
@@ -1136,211 +1130,211 @@ paths:
   /{municipalityId}/agreements:
     get:
       tags:
-        - Agreement
+      - Agreement
       summary: Get agreements
       description: Resource returns all agreements matching provided search parameters
       operationId: getAgreements
       parameters:
-        - name: municipalityId
-          in: path
-          description: Municipality id
-          required: true
-          schema:
-            type: string
-          example: 2281
-        - name: partyId
-          in: query
+      - name: municipalityId
+        in: path
+        description: Municipality id
+        required: true
+        schema:
+          type: string
+        example: 2281
+      - name: partyId
+        in: query
+        description: PartyId (e.g. a personId or an organizationId)
+        required: false
+        schema:
+          type: string
           description: PartyId (e.g. a personId or an organizationId)
-          required: false
-          schema:
-            type: string
-            description: PartyId (e.g. a personId or an organizationId)
-            examples:
-              - 81471222-5798-11e9-ae24-57fa13b361e1
-        - name: customerNumber
-          in: query
+          examples:
+          - 81471222-5798-11e9-ae24-57fa13b361e1
+      - name: customerNumber
+        in: query
+        description: Customer number
+        required: false
+        schema:
+          type: string
           description: Customer number
-          required: false
-          schema:
-            type: string
-            description: Customer number
-            examples:
-              - "10007"
-        - name: facilityId
-          in: query
+          examples:
+          - "10007"
+      - name: facilityId
+        in: query
+        description: Facility Id
+        required: false
+        schema:
+          type: string
           description: Facility Id
-          required: false
-          schema:
-            type: string
-            description: Facility Id
-            examples:
-              - "1223334"
-        - name: category
-          in: query
-          required: false
-          schema:
-            type: array
-            items:
-              $ref: "#/components/schemas/Category"
-        - name: billingId
-          in: query
+          examples:
+          - "1223334"
+      - name: category
+        in: query
+        required: false
+        schema:
+          type: array
+          items:
+            $ref: "#/components/schemas/Category"
+      - name: billingId
+        in: query
+        description: Billing Id
+        required: false
+        schema:
+          type: string
           description: Billing Id
-          required: false
-          schema:
-            type: string
-            description: Billing Id
-            examples:
-              - "222333"
-        - name: agreementId
-          in: query
+          examples:
+          - "222333"
+      - name: agreementId
+        in: query
+        description: Agreement Id
+        required: false
+        schema:
+          type: string
           description: Agreement Id
-          required: false
-          schema:
-            type: string
-            description: Agreement Id
-            examples:
-              - "333444"
-        - name: description
-          in: query
+          examples:
+          - "333444"
+      - name: description
+        in: query
+        description: Description
+        required: false
+        schema:
+          type: string
           description: Description
-          required: false
-          schema:
-            type: string
-            description: Description
-            examples:
-              - Avtalet avser fjärrvärme
-        - name: mainAgreement
-          in: query
+          examples:
+          - Avtalet avser fjärrvärme
+      - name: mainAgreement
+        in: query
+        description: Shows if agreement is a main-agreement or not
+        required: false
+        schema:
+          type: boolean
           description: Shows if agreement is a main-agreement or not
-          required: false
-          schema:
-            type: boolean
-            description: Shows if agreement is a main-agreement or not
-            examples:
-              - "true"
-        - name: binding
-          in: query
+          examples:
+          - "true"
+      - name: binding
+        in: query
+        description: Shows if agreement include binding or not
+        required: false
+        schema:
+          type: boolean
           description: Shows if agreement include binding or not
-          required: false
-          schema:
-            type: boolean
-            description: Shows if agreement include binding or not
-            examples:
-              - "false"
-        - name: bindingRule
-          in: query
+          examples:
+          - "false"
+      - name: bindingRule
+        in: query
+        description: Rule of binding if exists
+        required: false
+        schema:
+          type: string
           description: Rule of binding if exists
-          required: false
-          schema:
-            type: string
-            description: Rule of binding if exists
-            examples:
-              - 10 mån binding
-        - name: placementStatus
-          in: query
+          examples:
+          - 10 mån binding
+      - name: placementStatus
+        in: query
+        description: Placement status for agreement
+        required: false
+        schema:
+          type: string
           description: Placement status for agreement
-          required: false
-          schema:
-            type: string
-            description: Placement status for agreement
-            examples:
-              - Tillkopplad
-        - name: netAreaId
-          in: query
+          examples:
+          - Tillkopplad
+      - name: netAreaId
+        in: query
+        description: Net area id for agreement
+        required: false
+        schema:
+          type: string
           description: Net area id for agreement
-          required: false
-          schema:
-            type: string
-            description: Net area id for agreement
-            examples:
-              - SUV
-        - name: siteAddress
-          in: query
+          examples:
+          - SUV
+      - name: siteAddress
+        in: query
+        description: Site address connected to the agreement
+        required: false
+        schema:
+          type: string
           description: Site address connected to the agreement
-          required: false
-          schema:
-            type: string
-            description: Site address connected to the agreement
-            examples:
-              - Första gatan 2
-        - name: production
-          in: query
+          examples:
+          - Första gatan 2
+      - name: production
+        in: query
+        description: Signal if the agreement is a production agreement or not (can
+          be null if not applicable)
+        required: false
+        schema:
+          type: boolean
           description: Signal if the agreement is a production agreement or not (can
             be null if not applicable)
-          required: false
-          schema:
-            type: boolean
-            description: Signal if the agreement is a production agreement or not (can
-              be null if not applicable)
-            examples:
-              - "true"
-        - name: fromDate
-          in: query
+          examples:
+          - "true"
+      - name: fromDate
+        in: query
+        description: From-date in validity of agreement
+        required: false
+        schema:
+          type: string
+          format: date
           description: From-date in validity of agreement
-          required: false
-          schema:
-            type: string
-            format: date
-            description: From-date in validity of agreement
-        - name: toDate
-          in: query
+      - name: toDate
+        in: query
+        description: To-date in validity of agreement
+        required: false
+        schema:
+          type: string
+          format: date
           description: To-date in validity of agreement
-          required: false
-          schema:
-            type: string
-            format: date
-            description: To-date in validity of agreement
-        - name: active
-          in: query
+      - name: active
+        in: query
+        description: Shows if agreement is active ('fromDate' <= today and 'toDate'
+          => today). Null shows both active and inactive
+        required: false
+        schema:
+          type: boolean
           description: Shows if agreement is active ('fromDate' <= today and 'toDate'
             => today). Null shows both active and inactive
-          required: false
-          schema:
-            type: boolean
-            description: Shows if agreement is active ('fromDate' <= today and 'toDate'
-              => today). Null shows both active and inactive
+          examples:
+          - "true"
+      - name: sortBy
+        in: query
+        required: false
+        schema:
+          type: array
+          items:
+            type: string
+            description: The properties to sort on
             examples:
-              - "true"
-        - name: sortBy
-          in: query
-          required: false
-          schema:
-            type: array
-            items:
-              type: string
-              description: The properties to sort on
-              examples:
-                - propertyName
-        - name: sortDirection
-          in: query
-          description: The sort order direction
-          required: false
-          schema:
-            $ref: "#/components/schemas/Direction"
-        - name: page
-          in: query
+            - propertyName
+      - name: sortDirection
+        in: query
+        description: The sort order direction
+        required: false
+        schema:
+          $ref: "#/components/schemas/Direction"
+      - name: page
+        in: query
+        description: Page number
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 1
           description: Page number
-          required: false
-          schema:
-            type: integer
-            format: int32
-            default: 1
-            description: Page number
-            examples:
-              - "1"
-            minimum: 1
-        - name: limit
-          in: query
-          description: Result size per page. Maximum allowed value is dynamically configured
-          required: false
-          schema:
-            type: integer
-            format: int32
-            description: Result size per page. Maximum allowed value is dynamically
-              configured
-            examples:
-              - "15"
-            minimum: 1
+          examples:
+          - "1"
+          minimum: 1
+      - name: limit
+        in: query
+        description: Result size per page. Maximum allowed value is dynamically configured
+        required: false
+        schema:
+          type: integer
+          format: int32
+          description: Result size per page. Maximum allowed value is dynamically
+            configured
+          examples:
+          - "15"
+          minimum: 1
       responses:
         "200":
           description: OK - Successful operation
@@ -1354,8 +1348,8 @@ paths:
             application/problem+json:
               schema:
                 oneOf:
-                  - $ref: "#/components/schemas/Problem"
-                  - $ref: "#/components/schemas/ConstraintViolationProblem"
+                - $ref: "#/components/schemas/Problem"
+                - $ref: "#/components/schemas/ConstraintViolationProblem"
         "500":
           description: Internal Server error
           content:
@@ -1365,7 +1359,7 @@ paths:
   /api-docs:
     get:
       tags:
-        - API
+      - API
       summary: OpenAPI
       operationId: getApiDocs
       responses:
@@ -1383,9 +1377,9 @@ components:
     Problem:
       type: object
       properties:
-        title:
-          type: string
         detail:
+          type: string
+        title:
           type: string
         instance:
           type: string
@@ -1446,27 +1440,27 @@ components:
       type: string
       description: Category
       enum:
-        - COMMUNICATION
-        - DISTRICT_COOLING
-        - DISTRICT_HEATING
-        - ELECTRICITY
-        - ELECTRICITY_TRADE
-        - WASTE_MANAGEMENT
-        - WATER
+      - COMMUNICATION
+      - DISTRICT_COOLING
+      - DISTRICT_HEATING
+      - ELECTRICITY
+      - ELECTRICITY_TRADE
+      - WASTE_MANAGEMENT
+      - WATER
     Aggregation:
       type: string
       description: Data point aggregation granularity
       enum:
-        - QUARTER
-        - HOUR
-        - DAY
-        - MONTH
+      - QUARTER
+      - HOUR
+      - DAY
+      - MONTH
     Display:
       type: string
       description: Display mode for aggregated series
       enum:
-        - AGGREGATE
-        - ONLYAGGREGATED
+      - AGGREGATE
+      - ONLYAGGREGATED
     Measurement:
       type: object
       description: Measurement model
@@ -1475,68 +1469,68 @@ components:
           type: string
           description: Unique identifier for the measurement
           examples:
-            - 550e8400-e29b-41d4-a716-446655440000
+          - 550e8400-e29b-41d4-a716-446655440000
           readOnly: true
         customerOrgId:
           type: string
           description: Customer organization identifier
           examples:
-            - "5534567890"
+          - "5534567890"
           readOnly: true
         facilityId:
           type: string
           description: Facility identifier
           examples:
-            - "735999109151401011"
+          - "735999109151401011"
           readOnly: true
         feedType:
           type: string
           description: Type of feed
           examples:
-            - Energy
+          - Energy
           readOnly: true
         unit:
           type: string
           description: Measurement unit
           examples:
-            - kWh
+          - kWh
           readOnly: true
         usage:
           type: number
           description: Usage value
           examples:
-            - "1500"
+          - "1500"
           readOnly: true
         interpolation:
           type: integer
           format: int32
           description: Interpolation value indicating data quality
           examples:
-            - "0"
+          - "0"
           readOnly: true
         dateAndTime:
           type: string
           format: date-time
           description: Date and time of the measurement
           examples:
-            - 2024-01-15T10:30:00Z
+          - 2024-01-15T10:30:00Z
           readOnly: true
     CustomerType:
       type: string
       description: Customer type
       enum:
-        - Enterprise
-        - Private
+      - Enterprise
+      - Private
       examples:
-        - Enterprise
+      - Enterprise
     Direction:
       type: string
       description: The sort order direction
       enum:
-        - ASC
-        - DESC
+      - ASC
+      - DESC
       examples:
-        - ASC
+      - ASC
     Invoice:
       type: object
       description: Invoice model
@@ -1545,7 +1539,7 @@ components:
           type: string
           description: Customer number
           examples:
-            - "39195"
+          - "39195"
           readOnly: true
         customerType:
           $ref: "#/components/schemas/CustomerType"
@@ -1554,8 +1548,8 @@ components:
           type: array
           description: List of facility ids
           examples:
-            - "735999109151404321"
-            - "735999109151401234"
+          - "735999109151404321"
+          - "735999109151401234"
           items:
             type: string
           readOnly: true
@@ -1564,8 +1558,8 @@ components:
           type: array
           description: List of descriptions
           examples:
-            - Fjärrvärme
-            - Elnät
+          - Fjärrvärme
+          - Elnät
           items:
             type: string
           readOnly: true
@@ -1575,142 +1569,142 @@ components:
           format: int64
           description: Invoice number
           examples:
-            - "767915994"
+          - "767915994"
           readOnly: true
         invoiceDate:
           type: string
           format: date
           description: Invoice date
           examples:
-            - 2022-01-15
+          - 2022-01-15
           readOnly: true
         invoiceName:
           type: string
           description: invoice name
           examples:
-            - 765801493.pdf
+          - 765801493.pdf
           readOnly: true
         invoiceType:
           type: string
           description: Invoice type
           examples:
-            - Faktura
+          - Faktura
           readOnly: true
         invoiceStatus:
           type: string
           description: Invoice status
           examples:
-            - Skickad
+          - Skickad
           readOnly: true
         ocrNumber:
           type: integer
           format: int64
           description: Ocr number
           examples:
-            - "767915994"
+          - "767915994"
           readOnly: true
         dueDate:
           type: string
           format: date
           description: Due date
           examples:
-            - 2022-01-31
+          - 2022-01-31
           readOnly: true
         totalAmount:
           type: number
           description: Total amount
           examples:
-            - "1116.00"
+          - "1116.00"
           readOnly: true
         amountVatIncluded:
           type: number
           description: Amount included VAT
           examples:
-            - "1115.62"
+          - "1115.62"
           readOnly: true
         amountVatExcluded:
           type: number
           description: Amount excluded VAT
           examples:
-            - "892.50"
+          - "892.50"
           readOnly: true
         vatEligibleAmount:
           type: number
           description: Amount eligible for VAT
           examples:
-            - "892.50"
+          - "892.50"
           readOnly: true
         rounding:
           type: number
           description: Rounding
           examples:
-            - "0.38"
+          - "0.38"
           readOnly: true
         vat:
           type: number
           description: VAT
           examples:
-            - "892.50"
+          - "892.50"
           readOnly: true
         reversedVat:
           type: boolean
           description: Reversed VAT
           examples:
-            - "false"
+          - "false"
           readOnly: true
         currency:
           type: string
           description: Currency
           examples:
-            - sek
+          - sek
           readOnly: true
         organizationGroup:
           type: string
           description: Organization group
           examples:
-            - stadsbacken
+          - stadsbacken
           readOnly: true
         organizationNumber:
           type: string
           description: Organization number of invoice issuer
           examples:
-            - "5565027223"
+          - "5565027223"
           readOnly: true
         administration:
           type: string
           description: Adminstration
           examples:
-            - Sundsvall Elnät
+          - Sundsvall Elnät
           readOnly: true
         street:
           type: string
           description: Street
           examples:
-            - Storgatan 44
+          - Storgatan 44
           readOnly: true
         postCode:
           type: string
           description: Postal code
           examples:
-            - "85230"
+          - "85230"
           readOnly: true
         city:
           type: string
           description: City
           examples:
-            - Sundsvall
+          - Sundsvall
           readOnly: true
         careOf:
           type: string
           description: Care of address
           examples:
-            - Agatha Malm
+          - Agatha Malm
           readOnly: true
         pdfAvailable:
           type: boolean
           description: Is pdf-version of invoice available
           examples:
-            - "false"
+          - "false"
           readOnly: true
     InvoiceResponse:
       type: object
@@ -1733,35 +1727,35 @@ components:
           format: int32
           description: Current page
           examples:
-            - "5"
+          - "5"
           readOnly: true
         limit:
           type: integer
           format: int32
           description: Displayed objects per page
           examples:
-            - "20"
+          - "20"
           readOnly: true
         count:
           type: integer
           format: int32
           description: Displayed objects on current page
           examples:
-            - "13"
+          - "13"
           readOnly: true
         totalRecords:
           type: integer
           format: int64
           description: Total amount of hits based on provided search parameters
           examples:
-            - "98"
+          - "98"
           readOnly: true
         totalPages:
           type: integer
           format: int32
           description: Total amount of pages based on provided search parameters
           examples:
-            - "23"
+          - "23"
           readOnly: true
         sortBy:
           type: array
@@ -1769,13 +1763,13 @@ components:
             type: string
             description: The properties to sort by
             examples:
-              - property
+            - property
             readOnly: true
         sortDirection:
           $ref: "#/components/schemas/Direction"
           description: The sort order direction
           examples:
-            - ASC
+          - ASC
     InvoiceDetail:
       type: object
       description: Invoice detail model
@@ -1785,100 +1779,100 @@ components:
           format: int64
           description: Invoice number
           examples:
-            - "767915994"
+          - "767915994"
           readOnly: true
         amount:
           type: number
           description: Amount
           examples:
-            - "66.97"
+          - "66.97"
           readOnly: true
         amountVatExcluded:
           type: number
           description: Amount excluded VAT
           examples:
-            - "53.57"
+          - "53.57"
           readOnly: true
         vat:
           type: number
           description: VAT
           examples:
-            - "13.40"
+          - "13.40"
           readOnly: true
         vatRate:
           type: number
           format: double
           description: VAT rate
           examples:
-            - "25.0"
+          - "25.0"
           readOnly: true
         quantity:
           type: number
           format: double
           description: Quantity
           examples:
-            - "154.39"
+          - "154.39"
           readOnly: true
         unit:
           type: string
           description: Unit
           examples:
-            - kWh
+          - kWh
           readOnly: true
         unitPrice:
           type: number
           description: Price per unit
           examples:
-            - "0.347"
+          - "0.347"
           readOnly: true
         periodFrom:
           type: string
           description: Period from
           examples:
-            - 2022-01-01
+          - 2022-01-01
           readOnly: true
         periodTo:
           type: string
           description: Period to
           examples:
-            - 2022-01-31
+          - 2022-01-31
           readOnly: true
         description:
           type: string
           description: Description
           examples:
-            - This is a description
+          - This is a description
           readOnly: true
         productCode:
           type: integer
           format: int32
           description: Product code
           examples:
-            - "1404"
+          - "1404"
           readOnly: true
         productName:
           type: string
           description: Product name
           examples:
-            - Elöverföring
+          - Elöverföring
           readOnly: true
         organizationNumber:
           type: string
           description: Organization number of invoice issuer
           examples:
-            - "5565027223"
+          - "5565027223"
           readOnly: true
         administration:
           type: string
           description: Administration
           examples:
-            - Name of the administration
+          - Name of the administration
           readOnly: true
         facilityId:
           type: string
           description: Facility id
           examples:
-            - "735999109151401011"
+          - "735999109151401011"
           readOnly: true
     CustomerInvoice:
       type: object
@@ -1888,7 +1882,7 @@ components:
           type: string
           description: Customer number
           examples:
-            - "123456"
+          - "123456"
           readOnly: true
         customerType:
           $ref: "#/components/schemas/CustomerType"
@@ -1897,159 +1891,159 @@ components:
           type: string
           description: Facility id
           examples:
-            - "735999109425048010"
+          - "735999109425048010"
           readOnly: true
         invoiceNumber:
           type: integer
           format: int64
           description: Invoice number
           examples:
-            - "123456789"
+          - "123456789"
           readOnly: true
         invoiceId:
           type: integer
           format: int64
           description: Invoice id
           examples:
-            - "1062916396"
+          - "1062916396"
           readOnly: true
         jointInvoiceId:
           type: integer
           format: int64
           description: Joint invoice id
           examples:
-            - "123"
+          - "123"
           readOnly: true
         invoiceDate:
           type: string
           format: date
           description: Invoice date
           examples:
-            - 2025-10-08
+          - 2025-10-08
           readOnly: true
         invoiceName:
           type: string
           description: Invoice name
           examples:
-            - 123456789.pdf
+          - 123456789.pdf
           readOnly: true
         invoiceType:
           type: string
           description: Invoice type
           examples:
-            - Faktura
+          - Faktura
           readOnly: true
         invoiceDescription:
           type: string
           description: Invoice description
           examples:
-            - El
+          - El
           readOnly: true
         invoiceStatus:
           type: string
           description: Invoice status
           examples:
-            - Betalad
+          - Betalad
           readOnly: true
         ocrNumber:
           type: integer
           format: int64
           description: OCR number
           examples:
-            - "295334999"
+          - "295334999"
           readOnly: true
         dueDate:
           type: string
           format: date
           description: Due date
           examples:
-            - 2025-10-28
+          - 2025-10-28
           readOnly: true
         periodFrom:
           type: string
           format: date
           description: Invoice period start
           examples:
-            - 2025-09-01
+          - 2025-09-01
           readOnly: true
         periodTo:
           type: string
           format: date
           description: Invoice period end
           examples:
-            - 2025-09-30
+          - 2025-09-30
           readOnly: true
         totalAmount:
           type: number
           description: Total amount
           examples:
-            - "1234.00"
+          - "1234.00"
           readOnly: true
         amountVatIncluded:
           type: number
           description: Amount included VAT
           examples:
-            - "1233.51"
+          - "1233.51"
           readOnly: true
         amountVatExcluded:
           type: number
           description: Amount excluded VAT
           examples:
-            - "986.81"
+          - "986.81"
           readOnly: true
         vatEligibleAmount:
           type: number
           description: Amount eligible for VAT
           examples:
-            - "986.81"
+          - "986.81"
           readOnly: true
         rounding:
           type: number
           description: Rounding
           examples:
-            - "0.49"
+          - "0.49"
           readOnly: true
         organizationGroup:
           type: string
           description: Organization group
           examples:
-            - stadsbacken
+          - stadsbacken
           readOnly: true
         organizationNumber:
           type: string
           description: Organization number of invoice issuer
           examples:
-            - "5565027223"
+          - "5565027223"
           readOnly: true
         administration:
           type: string
           description: Administration
           examples:
-            - Sundsvall Elnät
+          - Sundsvall Elnät
           readOnly: true
         street:
           type: string
           description: Street
           examples:
-            - Ankeborgsvägen 11
+          - Ankeborgsvägen 11
           readOnly: true
         postCode:
           type: string
           description: Postal code
           examples:
-            - "87654"
+          - "87654"
           readOnly: true
         city:
           type: string
           description: City
           examples:
-            - Sundsvall
+          - Sundsvall
           readOnly: true
         careOf:
           type: string
           description: Care of address
           examples:
-            - Anka Kalle
+          - Anka Kalle
           readOnly: true
         invoiceReference:
           type: string
@@ -2059,7 +2053,7 @@ components:
           type: boolean
           description: Is pdf-version of invoice available
           examples:
-            - "true"
+          - "true"
           readOnly: true
         details:
           type: array
@@ -2086,83 +2080,83 @@ components:
           type: string
           description: Company
           examples:
-            - Sundsvall Energi AB
+          - Sundsvall Energi AB
           readOnly: true
         customerNumber:
           type: string
           description: Customer number
           examples:
-            - "104327"
+          - "104327"
           readOnly: true
         type:
           type: string
           description: Type
           examples:
-            - Fjärrvärme
+          - Fjärrvärme
           readOnly: true
         facilityId:
           type: string
           description: Facility id
           examples:
-            - "735999109270751042"
+          - "735999109270751042"
           readOnly: true
         placementId:
           type: integer
           format: int32
           description: Placement id
           examples:
-            - "5263"
+          - "5263"
           readOnly: true
         careOf:
           type: string
           description: Care of address
           examples:
-            - Agatha Malm
+          - Agatha Malm
           readOnly: true
         street:
           type: string
           description: Street
           examples:
-            - Storgatan 9
+          - Storgatan 9
           readOnly: true
         postCode:
           type: string
           description: Postal code
           examples:
-            - "85230"
+          - "85230"
           readOnly: true
         city:
           type: string
           description: City
           examples:
-            - Sundsvall
+          - Sundsvall
           readOnly: true
         propertyDesignation:
           type: string
           description: Property designation
           examples:
-            - Södermalm 1:27
+          - Södermalm 1:27
           readOnly: true
         dateFrom:
           type: string
           format: date
           description: From date
           examples:
-            - 2019-01-01
+          - 2019-01-01
           readOnly: true
         dateTo:
           type: string
           format: date
           description: To date
           examples:
-            - 2022-12-31
+          - 2022-12-31
           readOnly: true
         dateLastModified:
           type: string
           format: date
           description: Date when object was last modified (or null if never modified)
           examples:
-            - 2022-12-31
+          - 2022-12-31
           readOnly: true
         metaData:
           type: array
@@ -2179,25 +2173,25 @@ components:
           type: string
           description: Key
           examples:
-            - netarea
+          - netarea
           readOnly: true
         value:
           type: string
           description: Value
           examples:
-            - Sundsvall tätort
+          - Sundsvall tätort
           readOnly: true
         type:
           type: string
           description: Type
           examples:
-            - location
+          - location
           readOnly: true
         displayName:
           type: string
           description: Displayname
           examples:
-            - Nätområde
+          - Nätområde
           readOnly: true
     InstalledBaseResponse:
       type: object
@@ -2219,77 +2213,77 @@ components:
           type: string
           description: Company
           examples:
-            - Sundsvall Energi AB
+          - Sundsvall Energi AB
           readOnly: true
         type:
           type: string
           description: Type
           examples:
-            - Fjärrvärme
+          - Fjärrvärme
           readOnly: true
         facilityId:
           type: string
           description: Facility id
           examples:
-            - "735999109270751042"
+          - "735999109270751042"
           readOnly: true
         placementId:
           type: integer
           format: int32
           description: Placement id
           examples:
-            - "5263"
+          - "5263"
           readOnly: true
         careOf:
           type: string
           description: Care of address
           examples:
-            - Agatha Malm
+          - Agatha Malm
           readOnly: true
         street:
           type: string
           description: Street
           examples:
-            - Storgatan 9
+          - Storgatan 9
           readOnly: true
         postCode:
           type: string
           description: Post code
           examples:
-            - "85230"
+          - "85230"
           readOnly: true
         city:
           type: string
           description: City
           examples:
-            - Sundsvall
+          - Sundsvall
           readOnly: true
         propertyDesignation:
           type: string
           description: Property designation
           examples:
-            - Södermalm 1:27
+          - Södermalm 1:27
           readOnly: true
         dateFrom:
           type: string
           format: date
           description: From date
           examples:
-            - 2019-01-01
+          - 2019-01-01
           readOnly: true
         dateTo:
           type: string
           format: date
           description: To date
           examples:
-            - 2022-12-31
+          - 2022-12-31
           readOnly: true
         dateLastModified:
           type: string
           format: date
           description: Date when object was last modified (or null if never modified)
           examples:
-            - 2022-12-31
+          - 2022-12-31
           readOnly: true
         metaData:
           type: array
@@ -2317,25 +2311,25 @@ components:
           type: string
           description: Key
           examples:
-            - netarea
+          - netarea
           readOnly: true
         value:
           type: string
           description: Value
           examples:
-            - Sundsvall tätort
+          - Sundsvall tätort
           readOnly: true
         type:
           type: string
           description: Type
           examples:
-            - location
+          - location
           readOnly: true
         displayName:
           type: string
           description: Displayname
           examples:
-            - Nätområde
+          - Nätområde
           readOnly: true
     CustomerEngagement:
       type: object
@@ -2345,7 +2339,7 @@ components:
           type: string
           description: PartyId (e.g. a personId or an organizationId)
           examples:
-            - 81471222-5798-11e9-ae24-57fa13b361e1
+          - 81471222-5798-11e9-ae24-57fa13b361e1
           readOnly: true
         customerType:
           $ref: "#/components/schemas/CustomerType"
@@ -2354,26 +2348,26 @@ components:
           type: string
           description: Customer number
           examples:
-            - "10007"
+          - "10007"
           readOnly: true
         organizationNumber:
           type: string
           description: Organization number for counterpart of engagement
           examples:
-            - "5565027223"
+          - "5565027223"
           readOnly: true
         organizationName:
           type: string
           description: Organization name for counterpart of engagement
           examples:
-            - Sundsvall Elnät
+          - Sundsvall Elnät
           readOnly: true
         active:
           type: boolean
           description: "Indicates customer status, if not active then the moveInDate\
             \ holds information on when the customer will be activated"
           examples:
-            - "true"
+          - "true"
           readOnly: true
         moveInDate:
           type: string
@@ -2401,55 +2395,55 @@ components:
           description: Company with which the customer has an engagement (organization
             number)
           examples:
-            - "5591962591"
+          - "5591962591"
           readOnly: true
         customerEngagementOrgName:
           type: string
           description: Name of the company the customer has an engagement with
           examples:
-            - Sundsvall Elnät
+          - Sundsvall Elnät
           readOnly: true
         partyId:
           type: string
           description: PartyId (e.g. a personId or an organizationId)
           examples:
-            - 81471222-5798-11e9-ae24-57fa13b361e1
+          - 81471222-5798-11e9-ae24-57fa13b361e1
           readOnly: true
         customerNumber:
           type: string
           description: Customer number
           examples:
-            - "39195"
+          - "39195"
           readOnly: true
         customerName:
           type: string
           description: Customer name
           examples:
-            - Sven Svensson
+          - Sven Svensson
           readOnly: true
         street:
           type: string
           description: Street
           examples:
-            - Storgatan 44
+          - Storgatan 44
           readOnly: true
         postalCode:
           type: string
           description: Postal code
           examples:
-            - "85230"
+          - "85230"
           readOnly: true
         city:
           type: string
           description: City
           examples:
-            - Sundsvall
+          - Sundsvall
           readOnly: true
         careOf:
           type: string
           description: Care of address
           examples:
-            - Agatha Malm
+          - Agatha Malm
           readOnly: true
         phoneNumbers:
           type: array
@@ -2457,7 +2451,7 @@ components:
             type: string
             description: List of phoneNumbers
             examples:
-              - 076-1234567
+            - 076-1234567
             readOnly: true
         emails:
           type: array
@@ -2465,41 +2459,41 @@ components:
             type: string
             description: List of emailAddresses
             examples:
-              - test@test.se
+            - test@test.se
             readOnly: true
         customerCategoryID:
           type: integer
           format: int32
           description: Customer category ID
           examples:
-            - "1"
+          - "1"
           readOnly: true
         customerCategoryDescription:
           type: string
           description: Customer category description
           examples:
-            - Privat
+          - Privat
           readOnly: true
         customerChangedFlg:
           type: boolean
           description: Indicates if customer details have changed since the search
             date
           examples:
-            - PRIVATE
+          - PRIVATE
           readOnly: true
         installedChangedFlg:
           type: boolean
           description: Indicates if placement and/or equipment details have changed
             since the search date
           examples:
-            - "true"
+          - "true"
           readOnly: true
         active:
           type: boolean
           description: "Indicates customer status, if not active then the moveInDate\
             \ holds information on when the customer will be activated"
           examples:
-            - "true"
+          - "true"
           readOnly: true
         moveInDate:
           type: string
@@ -2526,19 +2520,19 @@ components:
           type: string
           description: PartyId (e.g. a personId or an organizationId)
           examples:
-            - 81471222-5798-11e9-ae24-57fa13b361e1
+          - 81471222-5798-11e9-ae24-57fa13b361e1
           readOnly: true
         customerNumber:
           type: string
           description: Customer number
           examples:
-            - "10007"
+          - "10007"
           readOnly: true
         facilityId:
           type: string
           description: Facility Id
           examples:
-            - "1223334"
+          - "1223334"
           readOnly: true
         category:
           $ref: "#/components/schemas/Category"
@@ -2547,62 +2541,62 @@ components:
           type: string
           description: Billing Id
           examples:
-            - "222333"
+          - "222333"
           readOnly: true
         agreementId:
           type: string
           description: Agreement Id
           examples:
-            - "333444"
+          - "333444"
           readOnly: true
         description:
           type: string
           description: Description
           examples:
-            - Avtalet avser fjärrvärme
+          - Avtalet avser fjärrvärme
           readOnly: true
         mainAgreement:
           type: boolean
           description: Shows if agreement is a main-agreement or not
           examples:
-            - "true"
+          - "true"
           readOnly: true
         binding:
           type: boolean
           description: Shows if agreement include binding or not
           examples:
-            - "false"
+          - "false"
           readOnly: true
         bindingRule:
           type: string
           description: Rule of binding if exists
           examples:
-            - 10 mån binding
+          - 10 mån binding
           readOnly: true
         placementStatus:
           type: string
           description: Placement status for agreement
           examples:
-            - Tillkopplad
+          - Tillkopplad
           readOnly: true
         netAreaId:
           type: string
           description: Net area id for agreement
           examples:
-            - SUV
+          - SUV
           readOnly: true
         siteAddress:
           type: string
           description: Site address connected to the agreement
           examples:
-            - Första gatan 2
+          - Första gatan 2
           readOnly: true
         production:
           type: boolean
           description: Signal if the agreement is a production agreement or not (can
             be null if not applicable)
           examples:
-            - "true"
+          - "true"
           readOnly: true
         fromDate:
           type: string
@@ -2619,7 +2613,7 @@ components:
           description: Shows if agreement is active ('fromDate' <= today and 'toDate'
             => today)
           examples:
-            - "true"
+          - "true"
           readOnly: true
     AgreementResponse:
       type: object


### PR DESCRIPTION
The endpoint returns a collection (List<InvoiceDetail>); an empty result is the natural REST shape and aligns it with the other invoice endpoints that already return 200 + empty for no matches. The 404 path was a sentinel for "no rows", which is indistinguishable from "the invoice exists but has no details" given the implementation just queries the detail rows directly.

Drop the throw in InvoiceService, the corresponding @ApiResponse(404) entry on the resource, and update the unit + integration tests / fixture to assert the new 200 + [] behavior.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
