### PR TITLE
hydran-2337: Support ASC/DESC sort direction for getInvoicesForCustomer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>se.sundsvall</groupId>
 	<artifactId>api-service-datawarehousereader</artifactId>
-	<version>5.6</version>
+	<version>5.7</version>
 	<name>api-service-datawarehousereader</name>
 	<description>A single store for fetching data used for tasks such as reporting, visualization and analytics.</description>
 	<properties>

--- a/src/integration-test/resources/GetInvoicesForCustomer/__files/test04_getForCustomerWithPaging/response.json
+++ b/src/integration-test/resources/GetInvoicesForCustomer/__files/test04_getForCustomerWithPaging/response.json
@@ -6,6 +6,7 @@
 		"sortBy": [
 			"InvoiceNumber"
 		],
+		"sortDirection": "ASC",
 		"totalPages": 3,
 		"totalRecords": 5
 	},

--- a/src/integration-test/resources/GetInvoicesForCustomer/__files/test08_getForCustomerWithInvalidSortByDefaultsToPeriodFrom/response.json
+++ b/src/integration-test/resources/GetInvoicesForCustomer/__files/test08_getForCustomerWithInvalidSortByDefaultsToPeriodFrom/response.json
@@ -6,6 +6,7 @@
 		"sortBy": [
 			"periodFrom"
 		],
+		"sortDirection": "ASC",
 		"totalPages": 1,
 		"totalRecords": 5
 	},

--- a/src/main/java/se/sundsvall/datawarehousereader/api/model/invoice/CustomerInvoiceParameters.java
+++ b/src/main/java/se/sundsvall/datawarehousereader/api/model/invoice/CustomerInvoiceParameters.java
@@ -10,11 +10,12 @@ import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Sort;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.format.annotation.DateTimeFormat.ISO;
-import se.sundsvall.dept44.models.api.paging.AbstractParameterPagingBase;
+
+import se.sundsvall.dept44.models.api.paging.AbstractParameterPagingAndSortingBase;
 
 @Schema(description = "Customer invoice request parameters model")
 @ParameterObject
-public class CustomerInvoiceParameters extends AbstractParameterPagingBase {
+public class CustomerInvoiceParameters extends AbstractParameterPagingAndSortingBase {
 
 	@ArraySchema(schema = @Schema(description = "Customer numbers", examples = "123456"), minItems = 1)
 	@NotEmpty
@@ -36,16 +37,6 @@ public class CustomerInvoiceParameters extends AbstractParameterPagingBase {
 	@Schema(description = "Latest invoice period end. Format is YYYY-MM-DD.", examples = "2025-12-31")
 	@DateTimeFormat(iso = ISO.DATE)
 	private LocalDate periodTo;
-
-	@Schema(description = "Column to sort by.", examples = {
-		"periodFrom", "periodTo", "InvoiceDate", "DueDate", "InvoiceNumber", "TotalAmount"
-	})
-	private String sortBy;
-
-	@Schema(description = "The sort order direction. Defaults to ASC when omitted.", examples = {
-		"ASC", "DESC"
-	}, enumAsRef = true)
-	private Sort.Direction sortDirection;
 
 	public static CustomerInvoiceParameters create() {
 		return new CustomerInvoiceParameters();
@@ -129,29 +120,31 @@ public class CustomerInvoiceParameters extends AbstractParameterPagingBase {
 		return this;
 	}
 
-	public String getSortBy() {
-		return sortBy;
+	@Override
+	@ArraySchema(schema = @Schema(description = "Column to sort by", examples = {
+		"periodFrom", "periodTo", "InvoiceDate", "DueDate", "InvoiceNumber", "TotalAmount"
+	}))
+	public List<String> getSortBy() {
+		return super.getSortBy();
 	}
 
-	public void setSortBy(final String sortBy) {
-		this.sortBy = sortBy;
-	}
-
-	public CustomerInvoiceParameters withSortBy(final String sortBy) {
-		this.sortBy = sortBy;
+	public CustomerInvoiceParameters withSortBy(final List<String> sortBy) {
+		setSortBy(sortBy);
 		return this;
 	}
 
-	public Sort.Direction getSortDirection() {
-		return sortDirection;
-	}
-
-	public void setSortDirection(final Sort.Direction sortDirection) {
-		this.sortDirection = sortDirection;
-	}
-
 	public CustomerInvoiceParameters withSortDirection(final Sort.Direction sortDirection) {
-		this.sortDirection = sortDirection;
+		setSortDirection(sortDirection);
+		return this;
+	}
+
+	public CustomerInvoiceParameters withPage(final int page) {
+		setPage(page);
+		return this;
+	}
+
+	public CustomerInvoiceParameters withLimit(final int limit) {
+		setLimit(limit);
 		return this;
 	}
 
@@ -159,7 +152,7 @@ public class CustomerInvoiceParameters extends AbstractParameterPagingBase {
 	public int hashCode() {
 		final int prime = 31;
 		int result = super.hashCode();
-		result = prime * result + Objects.hash(customerNumbers, organizationIds, facilityIds, status, periodFrom, periodTo, sortBy, sortDirection);
+		result = prime * result + Objects.hash(customerNumbers, organizationIds, facilityIds, status, periodFrom, periodTo, sortBy, sortDirection, page, limit);
 		return result;
 	}
 
@@ -181,7 +174,9 @@ public class CustomerInvoiceParameters extends AbstractParameterPagingBase {
 			&& Objects.equals(periodFrom, other.periodFrom)
 			&& Objects.equals(periodTo, other.periodTo)
 			&& Objects.equals(sortBy, other.sortBy)
-			&& sortDirection == other.sortDirection;
+			&& Objects.equals(sortDirection, other.sortDirection)
+			&& Objects.equals(page, other.page)
+			&& Objects.equals(limit, other.limit);
 	}
 
 	@Override

--- a/src/main/java/se/sundsvall/datawarehousereader/api/model/invoice/CustomerInvoiceParameters.java
+++ b/src/main/java/se/sundsvall/datawarehousereader/api/model/invoice/CustomerInvoiceParameters.java
@@ -7,6 +7,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
 import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Sort;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.format.annotation.DateTimeFormat.ISO;
 import se.sundsvall.dept44.models.api.paging.AbstractParameterPagingBase;
@@ -40,6 +41,11 @@ public class CustomerInvoiceParameters extends AbstractParameterPagingBase {
 		"periodFrom", "periodTo", "InvoiceDate", "DueDate", "InvoiceNumber", "TotalAmount"
 	})
 	private String sortBy;
+
+	@Schema(description = "The sort order direction. Defaults to ASC when omitted.", examples = {
+		"ASC", "DESC"
+	}, enumAsRef = true)
+	private Sort.Direction sortDirection;
 
 	public static CustomerInvoiceParameters create() {
 		return new CustomerInvoiceParameters();
@@ -136,11 +142,24 @@ public class CustomerInvoiceParameters extends AbstractParameterPagingBase {
 		return this;
 	}
 
+	public Sort.Direction getSortDirection() {
+		return sortDirection;
+	}
+
+	public void setSortDirection(final Sort.Direction sortDirection) {
+		this.sortDirection = sortDirection;
+	}
+
+	public CustomerInvoiceParameters withSortDirection(final Sort.Direction sortDirection) {
+		this.sortDirection = sortDirection;
+		return this;
+	}
+
 	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = super.hashCode();
-		result = prime * result + Objects.hash(customerNumbers, organizationIds, facilityIds, status, periodFrom, periodTo, sortBy);
+		result = prime * result + Objects.hash(customerNumbers, organizationIds, facilityIds, status, periodFrom, periodTo, sortBy, sortDirection);
 		return result;
 	}
 
@@ -161,7 +180,8 @@ public class CustomerInvoiceParameters extends AbstractParameterPagingBase {
 			&& Objects.equals(status, other.status)
 			&& Objects.equals(periodFrom, other.periodFrom)
 			&& Objects.equals(periodTo, other.periodTo)
-			&& Objects.equals(sortBy, other.sortBy);
+			&& Objects.equals(sortBy, other.sortBy)
+			&& sortDirection == other.sortDirection;
 	}
 
 	@Override
@@ -173,6 +193,7 @@ public class CustomerInvoiceParameters extends AbstractParameterPagingBase {
 			+ ", periodFrom=" + periodFrom
 			+ ", periodTo=" + periodTo
 			+ ", sortBy=" + sortBy
+			+ ", sortDirection=" + sortDirection
 			+ ", page=" + page
 			+ ", limit=" + limit + "]";
 	}

--- a/src/main/java/se/sundsvall/datawarehousereader/integration/stadsbacken/CustomerInvoiceQuery.java
+++ b/src/main/java/se/sundsvall/datawarehousereader/integration/stadsbacken/CustomerInvoiceQuery.java
@@ -1,6 +1,7 @@
 package se.sundsvall.datawarehousereader.integration.stadsbacken;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Objects;
 import org.springframework.data.domain.Sort;
 
@@ -21,7 +22,7 @@ public class CustomerInvoiceQuery {
 	private String status;
 	private LocalDate periodFrom;
 	private LocalDate periodTo;
-	private String sortBy;
+	private List<String> sortBy;
 	private Sort.Direction sortDirection;
 
 	public static CustomerInvoiceQuery create() {
@@ -132,15 +133,15 @@ public class CustomerInvoiceQuery {
 		return this;
 	}
 
-	public String getSortBy() {
+	public List<String> getSortBy() {
 		return sortBy;
 	}
 
-	public void setSortBy(final String sortBy) {
+	public void setSortBy(final List<String> sortBy) {
 		this.sortBy = sortBy;
 	}
 
-	public CustomerInvoiceQuery withSortBy(final String sortBy) {
+	public CustomerInvoiceQuery withSortBy(final List<String> sortBy) {
 		this.setSortBy(sortBy);
 		return this;
 	}

--- a/src/main/java/se/sundsvall/datawarehousereader/integration/stadsbacken/CustomerInvoiceQuery.java
+++ b/src/main/java/se/sundsvall/datawarehousereader/integration/stadsbacken/CustomerInvoiceQuery.java
@@ -2,6 +2,7 @@ package se.sundsvall.datawarehousereader.integration.stadsbacken;
 
 import java.time.LocalDate;
 import java.util.Objects;
+import org.springframework.data.domain.Sort;
 
 /**
  * Parameter object for {@link InvoiceJdbcRepository#getInvoices(CustomerInvoiceQuery)}.
@@ -21,6 +22,7 @@ public class CustomerInvoiceQuery {
 	private LocalDate periodFrom;
 	private LocalDate periodTo;
 	private String sortBy;
+	private Sort.Direction sortDirection;
 
 	public static CustomerInvoiceQuery create() {
 		return new CustomerInvoiceQuery();
@@ -143,9 +145,22 @@ public class CustomerInvoiceQuery {
 		return this;
 	}
 
+	public Sort.Direction getSortDirection() {
+		return sortDirection;
+	}
+
+	public void setSortDirection(final Sort.Direction sortDirection) {
+		this.sortDirection = sortDirection;
+	}
+
+	public CustomerInvoiceQuery withSortDirection(final Sort.Direction sortDirection) {
+		this.sortDirection = sortDirection;
+		return this;
+	}
+
 	@Override
 	public int hashCode() {
-		return Objects.hash(page, limit, customerIds, organizationIds, facilityIds, status, periodFrom, periodTo, sortBy);
+		return Objects.hash(page, limit, customerIds, organizationIds, facilityIds, status, periodFrom, periodTo, sortBy, sortDirection);
 	}
 
 	@Override
@@ -164,7 +179,8 @@ public class CustomerInvoiceQuery {
 			&& Objects.equals(status, other.status)
 			&& Objects.equals(periodFrom, other.periodFrom)
 			&& Objects.equals(periodTo, other.periodTo)
-			&& Objects.equals(sortBy, other.sortBy);
+			&& Objects.equals(sortBy, other.sortBy)
+			&& Objects.equals(sortDirection, other.sortDirection);
 	}
 
 	@Override
@@ -177,6 +193,7 @@ public class CustomerInvoiceQuery {
 			+ ", status=" + status
 			+ ", periodFrom=" + periodFrom
 			+ ", periodTo=" + periodTo
-			+ ", sortBy=" + sortBy + "]";
+			+ ", sortBy=" + sortBy
+			+ ", sortDirection=" + sortDirection + "]";
 	}
 }

--- a/src/main/java/se/sundsvall/datawarehousereader/integration/stadsbacken/InvoiceJdbcRepository.java
+++ b/src/main/java/se/sundsvall/datawarehousereader/integration/stadsbacken/InvoiceJdbcRepository.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.domain.Sort;
 import org.springframework.jdbc.core.ResultSetExtractor;
@@ -93,10 +94,9 @@ public class InvoiceJdbcRepository {
 	}
 
 	public CustomerInvoiceResponse getInvoices(final CustomerInvoiceQuery query) {
-
-		final var sortColumn = resolveSortColumn(query.getSortBy());
+		final var sortColumns = resolveSortColumns(query.getSortBy());
 		final var sortDirection = resolveSortDirection(query.getSortDirection());
-		final var metadataSortBy = isSupplied(query.getSortBy()) ? sortColumn : null;
+		final var metadataSortBy = isSupplied(query.getSortBy()) ? sortColumns : null;
 		final var metadataSortDirection = metadataSortBy != null ? sortDirection : null;
 
 		final var parameters = new MapSqlParameterSource()
@@ -106,35 +106,51 @@ public class InvoiceJdbcRepository {
 			.addValue(CUSTOMER_IDS, query.getCustomerIds())
 			.addValue(PERIOD_FROM, query.getPeriodFrom())
 			.addValue(PERIOD_TO, query.getPeriodTo())
-			.addValue(SORT_BY, sortColumn)
+			.addValue(SORT_BY, sortColumns.getFirst())  // resolveSortColumns always returns at least DEFAULT_SORT_COLUMN, i.e. no null here
 			.addValue(FACILITY_IDS, query.getFacilityIds())
 			.addValue(INVOICE_STATUS, query.getStatus())
 			.addValue(OFFSET, (query.getPage() - 1) * query.getLimit())
 			.addValue(FETCH, query.getLimit());
 
-		final var sql = SQL_TEMPLATE.replace(ORDER_BY_PLACEHOLDER, buildOrderByColumns(sortColumn, sortDirection));
+		final var sql = SQL_TEMPLATE.replace(ORDER_BY_PLACEHOLDER, buildOrderByColumns(sortColumns, sortDirection));
 
 		return jdbcTemplate.query(sql, parameters,
 			new CustomerInvoiceResponseExtractor(query.getPage(), query.getLimit(), metadataSortBy, metadataSortDirection));
 	}
 
 	/**
-	 * The requested direction is applied to the primary sort column only. The {@link #TIE_BREAKER_COLUMN} is always kept
-	 * ascending; it exists solely to make paging deterministic, so its direction is irrelevant. {@code direction.name()}
-	 * yields the literal {@code ASC} or {@code DESC}, so concatenating it into the statement is injection safe.
+	 * Applies the requested direction to every primary sort column, then appends the {@link #TIE_BREAKER_COLUMN} so paging
+	 * stays deterministic when the primary columns have duplicate values. The tie breaker is always kept ascending (its
+	 * direction is irrelevant) and is omitted when it is already one of the requested columns, since a column may appear
+	 * only once in an ORDER BY. {@code direction.name()} yields the literal {@code ASC} or {@code DESC} and every column
+	 * comes from the whitelist, so concatenating them into the statement is injection safe.
 	 */
-	private static String buildOrderByColumns(final String sortColumn, final Sort.Direction direction) {
-		final var primaryColumn = "inner_query." + sortColumn;
-		final var primaryClause = primaryColumn + " " + direction.name();
-		// Avoid "column specified more than once in the order by list" when sorting by the tie breaker itself.
-		return primaryColumn.equals(TIE_BREAKER_COLUMN) ? primaryClause : primaryClause + ", " + TIE_BREAKER_COLUMN;
+	private static String buildOrderByColumns(final List<String> sortColumns, final Sort.Direction direction) {
+		final var clauses = new ArrayList<String>();
+		sortColumns.forEach(column -> clauses.add("inner_query." + column + " " + direction.name()));
+		if (sortColumns.stream().noneMatch(column -> ("inner_query." + column).equals(TIE_BREAKER_COLUMN))) {
+			clauses.add(TIE_BREAKER_COLUMN);
+		}
+		return String.join(", ", clauses);
 	}
 
-	static String resolveSortColumn(final String sortBy) {
-		return ofNullable(sortBy)
+	/**
+	 * Maps each requested sort value to its whitelisted column, dropping anything not in the whitelist (which also guards
+	 * the ORDER BY against SQL injection). Falls back to {@link #DEFAULT_SORT_COLUMN} when nothing valid remains, so the
+	 * result is always non-empty.
+	 */
+	static List<String> resolveSortColumns(final List<String> sortBy) {
+		final var resolved = ofNullable(sortBy).orElseGet(List::of).stream()
+			.filter(Objects::nonNull)
 			.map(value -> value.trim().toLowerCase(Locale.ROOT))
 			.map(ALLOWED_SORT_COLUMNS::get)
-			.orElse(DEFAULT_SORT_COLUMN);
+			.filter(Objects::nonNull)
+			.toList();
+
+		if (resolved.isEmpty()) {
+			return List.of(DEFAULT_SORT_COLUMN);
+		}
+		return resolved;
 	}
 
 	/** A null direction (nothing requested) defaults to ascending, mirroring SQL's own default. */
@@ -142,18 +158,18 @@ public class InvoiceJdbcRepository {
 		return ofNullable(sortDirection).orElse(Sort.DEFAULT_DIRECTION);
 	}
 
-	private static boolean isSupplied(final String sortBy) {
-		return sortBy != null && !sortBy.isBlank();
+	private static boolean isSupplied(final List<String> sortBy) {
+		return sortBy != null && sortBy.stream().anyMatch(value -> value != null && !value.isBlank());
 	}
 
 	static class CustomerInvoiceResponseExtractor implements ResultSetExtractor<CustomerInvoiceResponse> {
 
 		private final int pageNumber;
 		private final int pageSize;
-		private final String sortBy;
+		private final List<String> sortBy;
 		private final Sort.Direction sortDirection;
 
-		CustomerInvoiceResponseExtractor(final int pageNumber, final int pageSize, final String sortBy, final Sort.Direction sortDirection) {
+		CustomerInvoiceResponseExtractor(final int pageNumber, final int pageSize, final List<String> sortBy, final Sort.Direction sortDirection) {
 			this.pageNumber = pageNumber;
 			this.pageSize = pageSize;
 			this.sortBy = sortBy;
@@ -180,7 +196,7 @@ public class InvoiceJdbcRepository {
 				.withCount(items.size())
 				.withTotalRecords(totalRecords)
 				.withTotalPages(totalPages)
-				.withSortBy(sortBy != null ? List.of(sortBy) : null)
+				.withSortBy(sortBy)
 				.withSortDirection(sortDirection);
 
 			return CustomerInvoiceResponse.create()

--- a/src/main/java/se/sundsvall/datawarehousereader/integration/stadsbacken/InvoiceJdbcRepository.java
+++ b/src/main/java/se/sundsvall/datawarehousereader/integration/stadsbacken/InvoiceJdbcRepository.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import org.springframework.dao.DataAccessException;
+import org.springframework.data.domain.Sort;
 import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -94,7 +95,9 @@ public class InvoiceJdbcRepository {
 	public CustomerInvoiceResponse getInvoices(final CustomerInvoiceQuery query) {
 
 		final var sortColumn = resolveSortColumn(query.getSortBy());
+		final var sortDirection = resolveSortDirection(query.getSortDirection());
 		final var metadataSortBy = isSupplied(query.getSortBy()) ? sortColumn : null;
+		final var metadataSortDirection = metadataSortBy != null ? sortDirection : null;
 
 		final var parameters = new MapSqlParameterSource()
 			.addValue(FUNCTION_PAGE_NUMBER, 1)
@@ -109,16 +112,22 @@ public class InvoiceJdbcRepository {
 			.addValue(OFFSET, (query.getPage() - 1) * query.getLimit())
 			.addValue(FETCH, query.getLimit());
 
-		final var sql = SQL_TEMPLATE.replace(ORDER_BY_PLACEHOLDER, buildOrderByColumns(sortColumn));
+		final var sql = SQL_TEMPLATE.replace(ORDER_BY_PLACEHOLDER, buildOrderByColumns(sortColumn, sortDirection));
 
 		return jdbcTemplate.query(sql, parameters,
-			new CustomerInvoiceResponseExtractor(query.getPage(), query.getLimit(), metadataSortBy));
+			new CustomerInvoiceResponseExtractor(query.getPage(), query.getLimit(), metadataSortBy, metadataSortDirection));
 	}
 
-	private static String buildOrderByColumns(final String sortColumn) {
+	/**
+	 * The requested direction is applied to the primary sort column only. The {@link #TIE_BREAKER_COLUMN} is always kept
+	 * ascending; it exists solely to make paging deterministic, so its direction is irrelevant. {@code direction.name()}
+	 * yields the literal {@code ASC} or {@code DESC}, so concatenating it into the statement is injection safe.
+	 */
+	private static String buildOrderByColumns(final String sortColumn, final Sort.Direction direction) {
 		final var primaryColumn = "inner_query." + sortColumn;
+		final var primaryClause = primaryColumn + " " + direction.name();
 		// Avoid "column specified more than once in the order by list" when sorting by the tie breaker itself.
-		return primaryColumn.equals(TIE_BREAKER_COLUMN) ? primaryColumn : primaryColumn + ", " + TIE_BREAKER_COLUMN;
+		return primaryColumn.equals(TIE_BREAKER_COLUMN) ? primaryClause : primaryClause + ", " + TIE_BREAKER_COLUMN;
 	}
 
 	static String resolveSortColumn(final String sortBy) {
@@ -126,6 +135,11 @@ public class InvoiceJdbcRepository {
 			.map(value -> value.trim().toLowerCase(Locale.ROOT))
 			.map(ALLOWED_SORT_COLUMNS::get)
 			.orElse(DEFAULT_SORT_COLUMN);
+	}
+
+	/** A null direction (nothing requested) defaults to ascending, mirroring SQL's own default. */
+	static Sort.Direction resolveSortDirection(final Sort.Direction sortDirection) {
+		return ofNullable(sortDirection).orElse(Sort.DEFAULT_DIRECTION);
 	}
 
 	private static boolean isSupplied(final String sortBy) {
@@ -137,11 +151,13 @@ public class InvoiceJdbcRepository {
 		private final int pageNumber;
 		private final int pageSize;
 		private final String sortBy;
+		private final Sort.Direction sortDirection;
 
-		CustomerInvoiceResponseExtractor(final int pageNumber, final int pageSize, final String sortBy) {
+		CustomerInvoiceResponseExtractor(final int pageNumber, final int pageSize, final String sortBy, final Sort.Direction sortDirection) {
 			this.pageNumber = pageNumber;
 			this.pageSize = pageSize;
 			this.sortBy = sortBy;
+			this.sortDirection = sortDirection;
 		}
 
 		@Override
@@ -164,7 +180,8 @@ public class InvoiceJdbcRepository {
 				.withCount(items.size())
 				.withTotalRecords(totalRecords)
 				.withTotalPages(totalPages)
-				.withSortBy(sortBy != null ? List.of(sortBy) : null);
+				.withSortBy(sortBy != null ? List.of(sortBy) : null)
+				.withSortDirection(sortDirection);
 
 			return CustomerInvoiceResponse.create()
 				.withMetaData(metaData)

--- a/src/main/java/se/sundsvall/datawarehousereader/service/InvoiceService.java
+++ b/src/main/java/se/sundsvall/datawarehousereader/service/InvoiceService.java
@@ -68,7 +68,8 @@ public class InvoiceService {
 			.withStatus(parameters.getStatus())
 			.withPeriodFrom(parameters.getPeriodFrom())
 			.withPeriodTo(parameters.getPeriodTo())
-			.withSortBy(parameters.getSortBy());
+			.withSortBy(parameters.getSortBy())
+			.withSortDirection(parameters.getSortDirection());
 
 		final var response = invoiceJdbcRepository.getInvoices(query);
 

--- a/src/test/java/se/sundsvall/datawarehousereader/api/InvoiceResourceTest.java
+++ b/src/test/java/se/sundsvall/datawarehousereader/api/InvoiceResourceTest.java
@@ -175,7 +175,6 @@ class InvoiceResourceTest {
 		final var organizationIds = "5565027223,5564786647";
 		final var periodFrom = LocalDate.of(2025, Month.JANUARY, 1);
 		final var periodTo = LocalDate.of(2025, Month.DECEMBER, 31);
-		final var sortBy = "periodFrom";
 
 		when(serviceMock.getInvoicesForCustomer(any())).thenReturn(CustomerInvoiceResponse.create());
 
@@ -186,7 +185,7 @@ class InvoiceResourceTest {
 			.queryParam("status", "Betalad")
 			.queryParam("periodFrom", periodFrom.format(DateTimeFormatter.ISO_LOCAL_DATE))
 			.queryParam("periodTo", periodTo.format(DateTimeFormatter.ISO_LOCAL_DATE))
-			.queryParam("sortBy", sortBy)
+			.queryParam("sortBy", "periodFrom", "InvoiceDate")
 			.queryParam("sortDirection", "DESC")
 			.queryParam("page", String.valueOf(PAGE))
 			.queryParam("limit", String.valueOf(LIMIT))
@@ -207,7 +206,7 @@ class InvoiceResourceTest {
 		assertThat(captured.getStatus()).isEqualTo("Betalad");
 		assertThat(captured.getPeriodFrom()).isEqualTo(periodFrom);
 		assertThat(captured.getPeriodTo()).isEqualTo(periodTo);
-		assertThat(captured.getSortBy()).isEqualTo(sortBy);
+		assertThat(captured.getSortBy()).containsExactly("periodFrom", "InvoiceDate");
 		assertThat(captured.getSortDirection()).isEqualTo(Sort.Direction.DESC);
 		assertThat(captured.getPage()).isEqualTo(PAGE);
 		assertThat(captured.getLimit()).isEqualTo(LIMIT);
@@ -237,7 +236,7 @@ class InvoiceResourceTest {
 		assertThat(captured.getPeriodFrom()).isNull();
 		assertThat(captured.getPeriodTo()).isNull();
 		assertThat(captured.getSortBy()).isNull();
-		assertThat(captured.getSortDirection()).isNull();
+		assertThat(captured.getSortDirection()).isEqualTo(Sort.Direction.ASC);
 		assertThat(captured.getPage()).isEqualTo(DEFAULT_PAGE);
 		assertThat(captured.getLimit()).isEqualTo(DEFAULT_LIMIT);
 	}

--- a/src/test/java/se/sundsvall/datawarehousereader/api/InvoiceResourceTest.java
+++ b/src/test/java/se/sundsvall/datawarehousereader/api/InvoiceResourceTest.java
@@ -12,6 +12,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.reactive.server.WebTestClient;
@@ -186,6 +187,7 @@ class InvoiceResourceTest {
 			.queryParam("periodFrom", periodFrom.format(DateTimeFormatter.ISO_LOCAL_DATE))
 			.queryParam("periodTo", periodTo.format(DateTimeFormatter.ISO_LOCAL_DATE))
 			.queryParam("sortBy", sortBy)
+			.queryParam("sortDirection", "DESC")
 			.queryParam("page", String.valueOf(PAGE))
 			.queryParam("limit", String.valueOf(LIMIT))
 			.build())
@@ -206,6 +208,7 @@ class InvoiceResourceTest {
 		assertThat(captured.getPeriodFrom()).isEqualTo(periodFrom);
 		assertThat(captured.getPeriodTo()).isEqualTo(periodTo);
 		assertThat(captured.getSortBy()).isEqualTo(sortBy);
+		assertThat(captured.getSortDirection()).isEqualTo(Sort.Direction.DESC);
 		assertThat(captured.getPage()).isEqualTo(PAGE);
 		assertThat(captured.getLimit()).isEqualTo(LIMIT);
 	}
@@ -234,6 +237,7 @@ class InvoiceResourceTest {
 		assertThat(captured.getPeriodFrom()).isNull();
 		assertThat(captured.getPeriodTo()).isNull();
 		assertThat(captured.getSortBy()).isNull();
+		assertThat(captured.getSortDirection()).isNull();
 		assertThat(captured.getPage()).isEqualTo(DEFAULT_PAGE);
 		assertThat(captured.getLimit()).isEqualTo(DEFAULT_LIMIT);
 	}

--- a/src/test/java/se/sundsvall/datawarehousereader/api/model/invoice/CustomerInvoiceParametersTest.java
+++ b/src/test/java/se/sundsvall/datawarehousereader/api/model/invoice/CustomerInvoiceParametersTest.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Random;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Sort;
 
 import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanConstructor;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanEquals;
@@ -42,6 +43,7 @@ class CustomerInvoiceParametersTest {
 		final var periodFrom = LocalDate.parse("2024-01-01").minusMonths(3);
 		final var periodTo = LocalDate.parse("2024-01-01");
 		final var sortBy = "periodFrom";
+		final var sortDirection = Sort.Direction.DESC;
 
 		final var parameters = CustomerInvoiceParameters.create()
 			.withCustomerNumbers(customerNumbers)
@@ -50,7 +52,8 @@ class CustomerInvoiceParametersTest {
 			.withStatus(status)
 			.withPeriodFrom(periodFrom)
 			.withPeriodTo(periodTo)
-			.withSortBy(sortBy);
+			.withSortBy(sortBy)
+			.withSortDirection(sortDirection);
 
 		assertThat(parameters).isNotNull();
 		assertThat(parameters.getCustomerNumbers()).isEqualTo(customerNumbers);
@@ -60,6 +63,7 @@ class CustomerInvoiceParametersTest {
 		assertThat(parameters.getPeriodFrom()).isEqualTo(periodFrom);
 		assertThat(parameters.getPeriodTo()).isEqualTo(periodTo);
 		assertThat(parameters.getSortBy()).isEqualTo(sortBy);
+		assertThat(parameters.getSortDirection()).isEqualTo(sortDirection);
 	}
 
 	@Test

--- a/src/test/java/se/sundsvall/datawarehousereader/api/model/invoice/CustomerInvoiceParametersTest.java
+++ b/src/test/java/se/sundsvall/datawarehousereader/api/model/invoice/CustomerInvoiceParametersTest.java
@@ -42,8 +42,10 @@ class CustomerInvoiceParametersTest {
 		final var status = "Betalad";
 		final var periodFrom = LocalDate.parse("2024-01-01").minusMonths(3);
 		final var periodTo = LocalDate.parse("2024-01-01");
-		final var sortBy = "periodFrom";
+		final var sortBy = List.of("periodFrom", "InvoiceDate");
 		final var sortDirection = Sort.Direction.DESC;
+		final var page = 1;
+		final var limit = 5;
 
 		final var parameters = CustomerInvoiceParameters.create()
 			.withCustomerNumbers(customerNumbers)
@@ -53,7 +55,9 @@ class CustomerInvoiceParametersTest {
 			.withPeriodFrom(periodFrom)
 			.withPeriodTo(periodTo)
 			.withSortBy(sortBy)
-			.withSortDirection(sortDirection);
+			.withSortDirection(sortDirection)
+			.withPage(page)
+			.withLimit(limit);
 
 		assertThat(parameters).isNotNull();
 		assertThat(parameters.getCustomerNumbers()).isEqualTo(customerNumbers);
@@ -64,18 +68,22 @@ class CustomerInvoiceParametersTest {
 		assertThat(parameters.getPeriodTo()).isEqualTo(periodTo);
 		assertThat(parameters.getSortBy()).isEqualTo(sortBy);
 		assertThat(parameters.getSortDirection()).isEqualTo(sortDirection);
+		assertThat(parameters.getPage()).isEqualTo(page);
+		assertThat(parameters.getLimit()).isEqualTo(limit);
 	}
 
 	@Test
 	void testNoDirtOnCreatedBean() {
 		assertThat(CustomerInvoiceParameters.create())
-			.hasAllNullFieldsOrPropertiesExcept("page", "limit")
+			.hasAllNullFieldsOrPropertiesExcept("page", "limit", "sortDirection")
 			.hasFieldOrPropertyWithValue("page", 1)
-			.hasFieldOrPropertyWithValue("limit", 100);
+			.hasFieldOrPropertyWithValue("limit", 100)
+			.hasFieldOrPropertyWithValue("sortDirection", Sort.Direction.ASC);
 
 		assertThat(new CustomerInvoiceParameters())
-			.hasAllNullFieldsOrPropertiesExcept("page", "limit")
+			.hasAllNullFieldsOrPropertiesExcept("page", "limit", "sortDirection")
 			.hasFieldOrPropertyWithValue("page", 1)
-			.hasFieldOrPropertyWithValue("limit", 100);
+			.hasFieldOrPropertyWithValue("limit", 100)
+			.hasFieldOrPropertyWithValue("sortDirection", Sort.Direction.ASC);
 	}
 }

--- a/src/test/java/se/sundsvall/datawarehousereader/integration/stadsbacken/CustomerInvoiceQueryTest.java
+++ b/src/test/java/se/sundsvall/datawarehousereader/integration/stadsbacken/CustomerInvoiceQueryTest.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.Random;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Sort;
 
 import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanConstructor;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanEquals;
@@ -43,6 +44,7 @@ class CustomerInvoiceQueryTest {
 		final var periodFrom = LocalDate.parse("2025-01-01");
 		final var periodTo = LocalDate.parse("2025-12-31");
 		final var sortBy = "periodFrom";
+		final var sortDirection = Sort.Direction.DESC;
 
 		final var query = CustomerInvoiceQuery.create()
 			.withPage(page)
@@ -53,7 +55,8 @@ class CustomerInvoiceQueryTest {
 			.withStatus(status)
 			.withPeriodFrom(periodFrom)
 			.withPeriodTo(periodTo)
-			.withSortBy(sortBy);
+			.withSortBy(sortBy)
+			.withSortDirection(sortDirection);
 
 		assertThat(query).isNotNull().hasNoNullFieldsOrProperties();
 		assertThat(query.getPage()).isEqualTo(page);
@@ -65,6 +68,7 @@ class CustomerInvoiceQueryTest {
 		assertThat(query.getPeriodFrom()).isEqualTo(periodFrom);
 		assertThat(query.getPeriodTo()).isEqualTo(periodTo);
 		assertThat(query.getSortBy()).isEqualTo(sortBy);
+		assertThat(query.getSortDirection()).isEqualTo(sortDirection);
 	}
 
 	@Test

--- a/src/test/java/se/sundsvall/datawarehousereader/integration/stadsbacken/CustomerInvoiceQueryTest.java
+++ b/src/test/java/se/sundsvall/datawarehousereader/integration/stadsbacken/CustomerInvoiceQueryTest.java
@@ -1,6 +1,7 @@
 package se.sundsvall.datawarehousereader.integration.stadsbacken;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Random;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -43,7 +44,7 @@ class CustomerInvoiceQueryTest {
 		final var status = "Betalad";
 		final var periodFrom = LocalDate.parse("2025-01-01");
 		final var periodTo = LocalDate.parse("2025-12-31");
-		final var sortBy = "periodFrom";
+		final var sortBy = List.of("periodFrom", "InvoiceDate");
 		final var sortDirection = Sort.Direction.DESC;
 
 		final var query = CustomerInvoiceQuery.create()

--- a/src/test/java/se/sundsvall/datawarehousereader/integration/stadsbacken/InvoiceJdbcRepositoryTest.java
+++ b/src/test/java/se/sundsvall/datawarehousereader/integration/stadsbacken/InvoiceJdbcRepositoryTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
@@ -20,6 +21,7 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Sort;
 import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -68,6 +70,7 @@ class InvoiceJdbcRepositoryTest {
 				.withPeriodFrom(periodFrom)
 				.withPeriodTo(periodTo)
 				.withSortBy("InvoiceNumber")
+				.withSortDirection(Sort.Direction.DESC)
 				.withFacilityIds(facilityIds)
 				.withStatus(invoiceStatus);
 
@@ -93,7 +96,48 @@ class InvoiceJdbcRepositoryTest {
 			assertThat(params.getValue("invoiceStatus")).isEqualTo(invoiceStatus);
 			assertThat(params.getValue("offset")).isEqualTo(10);
 			assertThat(params.getValue("fetch")).isEqualTo(10);
-			assertThat(sqlCaptor.getValue()).contains("ORDER BY inner_query.InvoiceNumber");
+			// InvoiceNumber is also the tie breaker, so it appears once with the requested direction
+			assertThat(sqlCaptor.getValue()).contains("ORDER BY inner_query.InvoiceNumber DESC")
+				.doesNotContain("inner_query.InvoiceNumber DESC, inner_query.InvoiceNumber");
+		}
+
+		@Test
+		void getInvoices_withDescendingDirection_appendsDescToPrimaryColumnAndKeepsTieBreakerAscending() {
+			when(jdbcTemplate.query(anyString(), any(MapSqlParameterSource.class), ArgumentMatchers.<ResultSetExtractor<CustomerInvoiceResponse>>any()))
+				.thenReturn(CustomerInvoiceResponse.create());
+
+			repository.getInvoices(CustomerInvoiceQuery.create()
+				.withPage(1)
+				.withLimit(10)
+				.withCustomerIds("123456")
+				.withSortBy("periodFrom")
+				.withSortDirection(Sort.Direction.DESC));
+
+			verify(jdbcTemplate).query(
+				sqlCaptor.capture(),
+				parametersCaptor.capture(),
+				ArgumentMatchers.<ResultSetExtractor<CustomerInvoiceResponse>>any());
+
+			assertThat(sqlCaptor.getValue()).contains("ORDER BY inner_query.periodFrom DESC, inner_query.InvoiceNumber");
+		}
+
+		@Test
+		void getInvoices_withNullDirection_defaultsToAscending() {
+			when(jdbcTemplate.query(anyString(), any(MapSqlParameterSource.class), ArgumentMatchers.<ResultSetExtractor<CustomerInvoiceResponse>>any()))
+				.thenReturn(CustomerInvoiceResponse.create());
+
+			repository.getInvoices(CustomerInvoiceQuery.create()
+				.withPage(1)
+				.withLimit(10)
+				.withCustomerIds("123456")
+				.withSortBy("periodTo"));
+
+			verify(jdbcTemplate).query(
+				sqlCaptor.capture(),
+				parametersCaptor.capture(),
+				ArgumentMatchers.<ResultSetExtractor<CustomerInvoiceResponse>>any());
+
+			assertThat(sqlCaptor.getValue()).contains("ORDER BY inner_query.periodTo ASC, inner_query.InvoiceNumber");
 		}
 
 		@Test
@@ -175,6 +219,21 @@ class InvoiceJdbcRepositoryTest {
 	}
 
 	@Nested
+	class ResolveSortDirection {
+
+		@ParameterizedTest
+		@EnumSource(Sort.Direction.class)
+		void keepsSuppliedDirection(final Sort.Direction direction) {
+			assertThat(InvoiceJdbcRepository.resolveSortDirection(direction)).isEqualTo(direction);
+		}
+
+		@Test
+		void defaultsNullToAscending() {
+			assertThat(InvoiceJdbcRepository.resolveSortDirection(null)).isEqualTo(Sort.Direction.ASC);
+		}
+	}
+
+	@Nested
 	class ExtractData {
 
 		@Mock
@@ -182,7 +241,7 @@ class InvoiceJdbcRepositoryTest {
 
 		@Test
 		void extractData_withMultipleRows_returnsItemsAndPagination() throws SQLException {
-			final var extractor = new CustomerInvoiceResponseExtractor(1, 10, "periodFrom");
+			final var extractor = new CustomerInvoiceResponseExtractor(1, 10, "periodFrom", Sort.Direction.ASC);
 
 			when(resultSet.next()).thenReturn(true, true, false);
 
@@ -245,11 +304,12 @@ class InvoiceJdbcRepositoryTest {
 			assertThat(meta.getTotalRecords()).isEqualTo(23);
 			assertThat(meta.getTotalPages()).isEqualTo(3);
 			assertThat(meta.getSortBy()).containsExactly("periodFrom");
+			assertThat(meta.getSortDirection()).isEqualTo(Sort.Direction.ASC);
 		}
 
 		@Test
 		void extractData_withEmptyResultSet_returnsEmptyListAndZeroPagination() throws SQLException {
-			final var extractor = new CustomerInvoiceResponseExtractor(1, 10, "periodFrom");
+			final var extractor = new CustomerInvoiceResponseExtractor(1, 10, "periodFrom", Sort.Direction.ASC);
 			when(resultSet.next()).thenReturn(false);
 
 			final var result = extractor.extractData(resultSet);
@@ -262,21 +322,23 @@ class InvoiceJdbcRepositoryTest {
 			assertThat(result.getMetaData().getTotalRecords()).isZero();
 			assertThat(result.getMetaData().getTotalPages()).isZero();
 			assertThat(result.getMetaData().getSortBy()).containsExactly("periodFrom");
+			assertThat(result.getMetaData().getSortDirection()).isEqualTo(Sort.Direction.ASC);
 		}
 
 		@Test
 		void extractData_withNullSortBy_returnsNullSortByInMetadata() throws SQLException {
-			final var extractor = new CustomerInvoiceResponseExtractor(1, 10, null);
+			final var extractor = new CustomerInvoiceResponseExtractor(1, 10, null, null);
 			when(resultSet.next()).thenReturn(false);
 
 			final var result = extractor.extractData(resultSet);
 
 			assertThat(result.getMetaData().getSortBy()).isNull();
+			assertThat(result.getMetaData().getSortDirection()).isNull();
 		}
 
 		@Test
 		void extractData_withNullDatesAndNumbers_mapsToNulls() throws SQLException {
-			final var extractor = new CustomerInvoiceResponseExtractor(1, 10, null);
+			final var extractor = new CustomerInvoiceResponseExtractor(1, 10, null, null);
 			when(resultSet.next()).thenReturn(true, false);
 
 			when(resultSet.getString("CustomerId")).thenReturn("123456");
@@ -319,7 +381,7 @@ class InvoiceJdbcRepositoryTest {
 
 		@Test
 		void extractData_computesPaginationFromFilteredTotal() throws SQLException {
-			final var extractor = new CustomerInvoiceResponseExtractor(2, 5, "periodFrom");
+			final var extractor = new CustomerInvoiceResponseExtractor(2, 5, "periodFrom", Sort.Direction.DESC);
 			when(resultSet.next()).thenReturn(true, false);
 
 			when(resultSet.getInt("FilteredTotalRecords")).thenReturn(42);
@@ -333,6 +395,7 @@ class InvoiceJdbcRepositoryTest {
 			assertThat(result.getMetaData().getTotalRecords()).isEqualTo(42);
 			assertThat(result.getMetaData().getTotalPages()).isEqualTo(9);
 			assertThat(result.getMetaData().getSortBy()).isEqualTo(List.of("periodFrom"));
+			assertThat(result.getMetaData().getSortDirection()).isEqualTo(Sort.Direction.DESC);
 		}
 	}
 }

--- a/src/test/java/se/sundsvall/datawarehousereader/integration/stadsbacken/InvoiceJdbcRepositoryTest.java
+++ b/src/test/java/se/sundsvall/datawarehousereader/integration/stadsbacken/InvoiceJdbcRepositoryTest.java
@@ -6,6 +6,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.LocalDate;
 import java.time.Month;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -13,7 +14,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
@@ -69,7 +69,7 @@ class InvoiceJdbcRepositoryTest {
 				.withCustomerIds(customerIds)
 				.withPeriodFrom(periodFrom)
 				.withPeriodTo(periodTo)
-				.withSortBy("InvoiceNumber")
+				.withSortBy(List.of("InvoiceNumber"))
 				.withSortDirection(Sort.Direction.DESC)
 				.withFacilityIds(facilityIds)
 				.withStatus(invoiceStatus);
@@ -110,7 +110,7 @@ class InvoiceJdbcRepositoryTest {
 				.withPage(1)
 				.withLimit(10)
 				.withCustomerIds("123456")
-				.withSortBy("periodFrom")
+				.withSortBy(List.of("periodFrom"))
 				.withSortDirection(Sort.Direction.DESC));
 
 			verify(jdbcTemplate).query(
@@ -122,6 +122,29 @@ class InvoiceJdbcRepositoryTest {
 		}
 
 		@Test
+		void getInvoices_withMultipleSortColumns_buildsMultiColumnOrderByAndPassesPrimaryToFunction() {
+			when(jdbcTemplate.query(anyString(), any(MapSqlParameterSource.class), ArgumentMatchers.<ResultSetExtractor<CustomerInvoiceResponse>>any()))
+				.thenReturn(CustomerInvoiceResponse.create());
+
+			repository.getInvoices(CustomerInvoiceQuery.create()
+				.withPage(1)
+				.withLimit(10)
+				.withCustomerIds("123456")
+				.withSortBy(List.of("periodFrom", "invoicedate"))
+				.withSortDirection(Sort.Direction.DESC));
+
+			verify(jdbcTemplate).query(
+				sqlCaptor.capture(),
+				parametersCaptor.capture(),
+				ArgumentMatchers.<ResultSetExtractor<CustomerInvoiceResponse>>any());
+
+			assertThat(sqlCaptor.getValue())
+				.contains("ORDER BY inner_query.periodFrom DESC, inner_query.InvoiceDate DESC, inner_query.InvoiceNumber");
+			// the SQL function only takes a single sort column, so it receives the primary (first) one
+			assertThat(parametersCaptor.getValue().getValue("sortBy")).isEqualTo("periodFrom");
+		}
+
+		@Test
 		void getInvoices_withNullDirection_defaultsToAscending() {
 			when(jdbcTemplate.query(anyString(), any(MapSqlParameterSource.class), ArgumentMatchers.<ResultSetExtractor<CustomerInvoiceResponse>>any()))
 				.thenReturn(CustomerInvoiceResponse.create());
@@ -130,7 +153,7 @@ class InvoiceJdbcRepositoryTest {
 				.withPage(1)
 				.withLimit(10)
 				.withCustomerIds("123456")
-				.withSortBy("periodTo"));
+				.withSortBy(List.of("periodTo")));
 
 			verify(jdbcTemplate).query(
 				sqlCaptor.capture(),
@@ -178,7 +201,7 @@ class InvoiceJdbcRepositoryTest {
 				.withPage(1)
 				.withLimit(10)
 				.withCustomerIds("123456")
-				.withSortBy("garble"));
+				.withSortBy(List.of("garble")));
 
 			verify(jdbcTemplate).query(
 				sqlCaptor.capture(),
@@ -191,7 +214,7 @@ class InvoiceJdbcRepositoryTest {
 	}
 
 	@Nested
-	class ResolveSortColumn {
+	class ResolveSortColumns {
 
 		@ParameterizedTest
 		@CsvSource({
@@ -201,20 +224,42 @@ class InvoiceJdbcRepositoryTest {
 			"DueDate, DueDate",
 			"invoicenumber, InvoiceNumber",
 			"totalamount, TotalAmount",
-			"' periodFrom ', periodFrom",
-			"garble, periodFrom"
+			"' periodFrom ', periodFrom"
 		})
-		void resolvesToWhitelistedColumnOrDefault(final String input, final String expected) {
-			assertThat(InvoiceJdbcRepository.resolveSortColumn(input)).isEqualTo(expected);
+		void mapsValueToWhitelistedColumn(final String input, final String expected) {
+			assertThat(InvoiceJdbcRepository.resolveSortColumns(List.of(input))).containsExactly(expected);
+		}
+
+		@Test
+		void keepsAllWhitelistedColumnsInRequestedOrder() {
+			assertThat(InvoiceJdbcRepository.resolveSortColumns(List.of("periodFrom", "invoicedate", "DUEDATE")))
+				.containsExactly("periodFrom", "InvoiceDate", "DueDate");
+		}
+
+		@Test
+		void dropsUnknownColumnsButKeepsValidOnes() {
+			assertThat(InvoiceJdbcRepository.resolveSortColumns(List.of("periodFrom", "garble", "totalamount")))
+				.containsExactly("periodFrom", "TotalAmount");
+		}
+
+		@Test
+		void ignoresNullElements() {
+			assertThat(InvoiceJdbcRepository.resolveSortColumns(Arrays.asList("periodFrom", null)))
+				.containsExactly("periodFrom");
 		}
 
 		@ParameterizedTest
-		@NullAndEmptySource
 		@ValueSource(strings = {
-			"   "
+			"garble", "   "
 		})
-		void resolvesNullOrBlankToDefault(final String input) {
-			assertThat(InvoiceJdbcRepository.resolveSortColumn(input)).isEqualTo("periodFrom");
+		void defaultsToPeriodFromWhenNoValidColumn(final String input) {
+			assertThat(InvoiceJdbcRepository.resolveSortColumns(List.of(input))).containsExactly("periodFrom");
+		}
+
+		@Test
+		void defaultsToPeriodFromWhenNullOrEmpty() {
+			assertThat(InvoiceJdbcRepository.resolveSortColumns(null)).containsExactly("periodFrom");
+			assertThat(InvoiceJdbcRepository.resolveSortColumns(List.of())).containsExactly("periodFrom");
 		}
 	}
 
@@ -241,7 +286,7 @@ class InvoiceJdbcRepositoryTest {
 
 		@Test
 		void extractData_withMultipleRows_returnsItemsAndPagination() throws SQLException {
-			final var extractor = new CustomerInvoiceResponseExtractor(1, 10, "periodFrom", Sort.Direction.ASC);
+			final var extractor = new CustomerInvoiceResponseExtractor(1, 10, List.of("periodFrom"), Sort.Direction.ASC);
 
 			when(resultSet.next()).thenReturn(true, true, false);
 
@@ -309,7 +354,7 @@ class InvoiceJdbcRepositoryTest {
 
 		@Test
 		void extractData_withEmptyResultSet_returnsEmptyListAndZeroPagination() throws SQLException {
-			final var extractor = new CustomerInvoiceResponseExtractor(1, 10, "periodFrom", Sort.Direction.ASC);
+			final var extractor = new CustomerInvoiceResponseExtractor(1, 10, List.of("periodFrom"), Sort.Direction.ASC);
 			when(resultSet.next()).thenReturn(false);
 
 			final var result = extractor.extractData(resultSet);
@@ -381,7 +426,7 @@ class InvoiceJdbcRepositoryTest {
 
 		@Test
 		void extractData_computesPaginationFromFilteredTotal() throws SQLException {
-			final var extractor = new CustomerInvoiceResponseExtractor(2, 5, "periodFrom", Sort.Direction.DESC);
+			final var extractor = new CustomerInvoiceResponseExtractor(2, 5, List.of("periodFrom"), Sort.Direction.DESC);
 			when(resultSet.next()).thenReturn(true, false);
 
 			when(resultSet.getInt("FilteredTotalRecords")).thenReturn(42);

--- a/src/test/java/se/sundsvall/datawarehousereader/service/InvoiceServiceTest.java
+++ b/src/test/java/se/sundsvall/datawarehousereader/service/InvoiceServiceTest.java
@@ -142,7 +142,7 @@ class InvoiceServiceTest {
 			.withStatus("Betalad")
 			.withPeriodFrom(LocalDate.of(2025, Month.JANUARY, 1))
 			.withPeriodTo(LocalDate.of(2025, Month.DECEMBER, 31))
-			.withSortBy("periodFrom")
+			.withSortBy(List.of("periodFrom", "InvoiceDate"))
 			.withSortDirection(Sort.Direction.DESC);
 		parameters.setPage(2);
 		parameters.setLimit(5);
@@ -183,7 +183,7 @@ class InvoiceServiceTest {
 		assertThat(query.getStatus()).isEqualTo("Betalad");
 		assertThat(query.getPeriodFrom()).isEqualTo(LocalDate.of(2025, Month.JANUARY, 1));
 		assertThat(query.getPeriodTo()).isEqualTo(LocalDate.of(2025, Month.DECEMBER, 31));
-		assertThat(query.getSortBy()).isEqualTo("periodFrom");
+		assertThat(query.getSortBy()).isEqualTo(List.of("periodFrom", "InvoiceDate"));
 		assertThat(query.getSortDirection()).isEqualTo(Sort.Direction.DESC);
 		verify(invoiceDetailRepositoryMock).findAllByOrganizationIdAndInvoiceNumber(organizationA, invoiceA);
 		verify(invoiceDetailRepositoryMock).findAllByOrganizationIdAndInvoiceNumber(organizationB, invoiceB);

--- a/src/test/java/se/sundsvall/datawarehousereader/service/InvoiceServiceTest.java
+++ b/src/test/java/se/sundsvall/datawarehousereader/service/InvoiceServiceTest.java
@@ -142,7 +142,8 @@ class InvoiceServiceTest {
 			.withStatus("Betalad")
 			.withPeriodFrom(LocalDate.of(2025, Month.JANUARY, 1))
 			.withPeriodTo(LocalDate.of(2025, Month.DECEMBER, 31))
-			.withSortBy("periodFrom");
+			.withSortBy("periodFrom")
+			.withSortDirection(Sort.Direction.DESC);
 		parameters.setPage(2);
 		parameters.setLimit(5);
 
@@ -183,6 +184,7 @@ class InvoiceServiceTest {
 		assertThat(query.getPeriodFrom()).isEqualTo(LocalDate.of(2025, Month.JANUARY, 1));
 		assertThat(query.getPeriodTo()).isEqualTo(LocalDate.of(2025, Month.DECEMBER, 31));
 		assertThat(query.getSortBy()).isEqualTo("periodFrom");
+		assertThat(query.getSortDirection()).isEqualTo(Sort.Direction.DESC);
 		verify(invoiceDetailRepositoryMock).findAllByOrganizationIdAndInvoiceNumber(organizationA, invoiceA);
 		verify(invoiceDetailRepositoryMock).findAllByOrganizationIdAndInvoiceNumber(organizationB, invoiceB);
 	}

--- a/src/test/resources/api/openapi.yaml
+++ b/src/test/resources/api/openapi.yaml
@@ -5,7 +5,7 @@ info:
   license:
     name: MIT License
     url: https://opensource.org/licenses/MIT
-  version: "5.6"
+  version: "5.7"
 servers:
 - url: http://localhost:53033
   description: Generated server url
@@ -487,6 +487,12 @@ paths:
           - DueDate
           - InvoiceNumber
           - TotalAmount
+      - name: sortDirection
+        in: query
+        description: The sort order direction. Defaults to ASC when omitted.
+        required: false
+        schema:
+          $ref: "#/components/schemas/Direction"
       - name: page
         in: query
         description: Page number

--- a/src/test/resources/api/openapi.yaml
+++ b/src/test/resources/api/openapi.yaml
@@ -475,21 +475,22 @@ paths:
           - 2025-12-31
       - name: sortBy
         in: query
-        description: Column to sort by.
         required: false
         schema:
-          type: string
-          description: Column to sort by.
-          examples:
-          - periodFrom
-          - periodTo
-          - InvoiceDate
-          - DueDate
-          - InvoiceNumber
-          - TotalAmount
+          type: array
+          items:
+            type: string
+            description: Column to sort by
+            examples:
+            - periodFrom
+            - periodTo
+            - InvoiceDate
+            - DueDate
+            - InvoiceNumber
+            - TotalAmount
       - name: sortDirection
         in: query
-        description: The sort order direction. Defaults to ASC when omitted.
+        description: The sort order direction
         required: false
         schema:
           $ref: "#/components/schemas/Direction"


### PR DESCRIPTION
Add a sortDirection parameter (org.springframework.data.domain.Sort.Direction) to CustomerInvoiceParameters, threaded through CustomerInvoiceQuery into InvoiceJdbcRepository. The direction is applied to the primary ORDER BY column (null defaults to ASC, matching SQL); the InvoiceNumber tie breaker stays ascending for deterministic paging. The applied direction is echoed back in the response _meta, mirroring the /invoices endpoint.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [x] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
