### PR TITLE
fix: aggregate all invoice description/facility rows in getInvoices

### DIFF
--- a/src/main/java/se/sundsvall/datawarehousereader/integration/stadsbacken/InvoiceJdbcRepository.java
+++ b/src/main/java/se/sundsvall/datawarehousereader/integration/stadsbacken/InvoiceJdbcRepository.java
@@ -13,11 +13,13 @@ import java.util.Objects;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.domain.Sort;
 import org.springframework.jdbc.core.ResultSetExtractor;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 import se.sundsvall.datawarehousereader.api.model.invoice.CustomerInvoice;
 import se.sundsvall.datawarehousereader.api.model.invoice.CustomerInvoiceResponse;
+import se.sundsvall.datawarehousereader.integration.stadsbacken.model.invoice.InvoiceEntity;
 import se.sundsvall.dept44.models.api.paging.PagingAndSortingMetaData;
 
 import static java.util.Optional.ofNullable;
@@ -87,6 +89,17 @@ public class InvoiceJdbcRepository {
 		ORDER BY {orderByColumns}
 		OFFSET :offset ROWS FETCH NEXT :fetch ROWS ONLY""";
 
+	/**
+	 * Reads the raw invoice view rows for a set of invoice numbers. The view name must match the {@code @Table} mapping on
+	 * {@link InvoiceEntity}. {@code OPTION (RECOMPILE)} mirrors the {@code @WithRecompile} hint the previous JPA query
+	 * used;
+	 * the Hibernate-based hint does not apply to plain JDBC, so it is added to the statement directly.
+	 */
+	private static final String SELECT_INVOICE_ROWS_SQL = """
+		SELECT * FROM [kundinfo].[vInvoice_Test_251126]
+		WHERE InvoiceNumber IN (:invoiceNumbers)
+		OPTION (RECOMPILE)""";
+
 	private final NamedParameterJdbcTemplate jdbcTemplate;
 
 	public InvoiceJdbcRepository(final NamedParameterJdbcTemplate jdbcTemplate) {
@@ -116,6 +129,22 @@ public class InvoiceJdbcRepository {
 
 		return jdbcTemplate.query(sql, parameters,
 			new CustomerInvoiceResponseExtractor(query.getPage(), query.getLimit(), metadataSortBy, metadataSortDirection));
+	}
+
+	/**
+	 * Fetches every underlying view row for the supplied invoice numbers.
+	 * <p>
+	 * The invoice view returns multiple rows per invoice (one per facility/description line). Reading those rows through
+	 * JPA collapses them into a single entity per invoice number, because {@link InvoiceEntity}'s identifier is the invoice
+	 * number alone and Hibernate deduplicates by entity identity. This JDBC read bypasses the persistence context, so every
+	 * row is returned and the caller can aggregate facilities and descriptions correctly.
+	 */
+	public List<InvoiceEntity> findAllByInvoiceNumberIn(final List<Long> invoiceNumbers) {
+		if (invoiceNumbers == null || invoiceNumbers.isEmpty()) {
+			return List.of();
+		}
+		final var parameters = new MapSqlParameterSource().addValue("invoiceNumbers", invoiceNumbers);
+		return jdbcTemplate.query(SELECT_INVOICE_ROWS_SQL, parameters, new InvoiceRowMapper());
 	}
 
 	/**
@@ -263,6 +292,65 @@ public class InvoiceJdbcRepository {
 		private static Boolean getNullableBoolean(final ResultSet rs, final String columnName) throws SQLException {
 			final var value = rs.getBoolean(columnName);
 			return rs.wasNull() ? null : value;
+		}
+	}
+
+	/**
+	 * Maps a single invoice view row to a detached {@link InvoiceEntity}. One entity is produced per row (no
+	 * deduplication),
+	 * so callers see every facility/description line for an invoice.
+	 */
+	static class InvoiceRowMapper implements RowMapper<InvoiceEntity> {
+
+		@Override
+		public InvoiceEntity mapRow(final ResultSet rs, final int rowNum) throws SQLException {
+			final var entity = new InvoiceEntity();
+			entity.setInvoiceNumber(rs.getLong("InvoiceNumber"));
+			entity.setInvoiceDate(toLocalDate(rs.getDate("InvoiceDate")));
+			entity.setInvoiceName(rs.getString("InvoiceName"));
+			entity.setInvoiceType(rs.getString("InvoiceType"));
+			entity.setInvoiceDescription(rs.getString("InvoiceDescription"));
+			entity.setInvoiceStatus(rs.getString("InvoiceStatus"));
+			entity.setOcrNumber(getNullableLong(rs, "OcrNumber"));
+			entity.setDueDate(toLocalDate(rs.getDate("DueDate")));
+			entity.setTotalAmount(rs.getBigDecimal("TotalAmount"));
+			entity.setAmountVatIncluded(rs.getBigDecimal("AmountVatIncluded"));
+			entity.setAmountVatExcluded(rs.getBigDecimal("AmountVatExcluded"));
+			entity.setVatEligibleAmount(rs.getBigDecimal("VatEligiblaAmount"));
+			entity.setRounding(rs.getBigDecimal("Rounding"));
+			entity.setVat(rs.getBigDecimal("Vat"));
+			entity.setReversedVat(toBoolean(rs.getString("ReversedVat")));
+			entity.setCurrency(rs.getString("Currency"));
+			entity.setCustomerId(rs.getInt("CustomerId"));
+			entity.setCustomerType(rs.getString("CustomerType"));
+			entity.setFacilityId(rs.getString("FacilityId"));
+			entity.setOrganizationGroup(rs.getString("OrganizationGroup"));
+			entity.setAdministration(rs.getString("Administration"));
+			entity.setOrganizationId(rs.getString("OrganizationId"));
+			entity.setStreet(rs.getString("Street"));
+			entity.setPostCode(rs.getString("PostalCode"));
+			entity.setCity(rs.getString("City"));
+			entity.setCareOf(rs.getString("CareOf"));
+			entity.setPdfAvailable(toBoolean(rs.getString("PdfAvailable")));
+			return entity;
+		}
+
+		private static LocalDate toLocalDate(final java.sql.Date date) {
+			return date != null ? date.toLocalDate() : null;
+		}
+
+		private static Long getNullableLong(final ResultSet rs, final String columnName) throws SQLException {
+			final var value = rs.getLong(columnName);
+			return rs.wasNull() ? null : value;
+		}
+
+		/**
+		 * The invoice view stores the boolean flags as strings ('true'/'false', and the literal text 'NULL'). This mirrors
+		 * the previous Hibernate mapping, which resolved anything other than 'true' (case-insensitive) to false. '1' is also
+		 * treated as true, in case the source ever exposes the column as a bit.
+		 */
+		private static Boolean toBoolean(final String value) {
+			return "true".equalsIgnoreCase(value) || "1".equals(value);
 		}
 	}
 }

--- a/src/main/java/se/sundsvall/datawarehousereader/integration/stadsbacken/InvoiceRepository.java
+++ b/src/main/java/se/sundsvall/datawarehousereader/integration/stadsbacken/InvoiceRepository.java
@@ -2,7 +2,6 @@ package se.sundsvall.datawarehousereader.integration.stadsbacken;
 
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -19,9 +18,6 @@ import static se.sundsvall.datawarehousereader.integration.stadsbacken.specifica
 @Transactional(readOnly = true)
 @CircuitBreaker(name = "invoiceRepository")
 public interface InvoiceRepository extends PagingAndSortingRepository<InvoiceEntity, Integer>, JpaSpecificationExecutor<InvoiceEntity> {
-
-	@WithRecompile
-	List<InvoiceEntity> findAllByInvoiceNumberIn(final List<Long> invoiceNumbers);
 
 	@WithRecompile
 	default Page<Long> findDistinctInvoiceNumbers(final InvoiceParameters parameters, final Pageable pageable) {

--- a/src/main/java/se/sundsvall/datawarehousereader/service/InvoiceService.java
+++ b/src/main/java/se/sundsvall/datawarehousereader/service/InvoiceService.java
@@ -46,7 +46,7 @@ public class InvoiceService {
 
 		Page<Long> invoiceNumbers = invoiceRepository.findDistinctInvoiceNumbers(parameters, pageable);
 
-		var invoiceEntities = invoiceRepository.findAllByInvoiceNumberIn(invoiceNumbers.getContent());
+		var invoiceEntities = invoiceJdbcRepository.findAllByInvoiceNumberIn(invoiceNumbers.getContent());
 
 		var invoiceMap = invoiceEntities.stream()
 			.collect(groupingBy(InvoiceEntity::getInvoiceNumber, Collectors.toList()));

--- a/src/test/java/se/sundsvall/datawarehousereader/integration/stadsbacken/InvoiceJdbcRepositoryTest.java
+++ b/src/test/java/se/sundsvall/datawarehousereader/integration/stadsbacken/InvoiceJdbcRepositoryTest.java
@@ -23,16 +23,20 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Sort;
 import org.springframework.jdbc.core.ResultSetExtractor;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import se.sundsvall.datawarehousereader.api.model.CustomerType;
 import se.sundsvall.datawarehousereader.api.model.invoice.CustomerInvoiceResponse;
 import se.sundsvall.datawarehousereader.integration.stadsbacken.InvoiceJdbcRepository.CustomerInvoiceResponseExtractor;
+import se.sundsvall.datawarehousereader.integration.stadsbacken.InvoiceJdbcRepository.InvoiceRowMapper;
+import se.sundsvall.datawarehousereader.integration.stadsbacken.model.invoice.InvoiceEntity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -441,6 +445,142 @@ class InvoiceJdbcRepositoryTest {
 			assertThat(result.getMetaData().getTotalPages()).isEqualTo(9);
 			assertThat(result.getMetaData().getSortBy()).isEqualTo(List.of("periodFrom"));
 			assertThat(result.getMetaData().getSortDirection()).isEqualTo(Sort.Direction.DESC);
+		}
+	}
+
+	@Nested
+	class FindAllByInvoiceNumberIn {
+
+		@Test
+		void withInvoiceNumbers_runsRecompiledInQueryAndReturnsRows() {
+			final var invoiceNumbers = List.of(138023999L, 139349898L);
+			final var rows = List.of(new InvoiceEntity());
+
+			when(jdbcTemplate.query(anyString(), any(MapSqlParameterSource.class), ArgumentMatchers.<RowMapper<InvoiceEntity>>any()))
+				.thenReturn(rows);
+
+			final var result = repository.findAllByInvoiceNumberIn(invoiceNumbers);
+
+			verify(jdbcTemplate).query(sqlCaptor.capture(), parametersCaptor.capture(), ArgumentMatchers.<RowMapper<InvoiceEntity>>any());
+
+			assertThat(result).isSameAs(rows);
+			assertThat(sqlCaptor.getValue())
+				.contains("[kundinfo].[vInvoice_Test_251126]")
+				.contains("WHERE InvoiceNumber IN (:invoiceNumbers)")
+				.contains("OPTION (RECOMPILE)");
+			assertThat(parametersCaptor.getValue().getValue("invoiceNumbers")).isEqualTo(invoiceNumbers);
+		}
+
+		@Test
+		void withEmptyList_returnsEmptyAndSkipsQuery() {
+			assertThat(repository.findAllByInvoiceNumberIn(List.of())).isEmpty();
+			verifyNoInteractions(jdbcTemplate);
+		}
+
+		@Test
+		void withNull_returnsEmptyAndSkipsQuery() {
+			assertThat(repository.findAllByInvoiceNumberIn(null)).isEmpty();
+			verifyNoInteractions(jdbcTemplate);
+		}
+	}
+
+	@Nested
+	class InvoiceRowMapperTest {
+
+		@Mock
+		private ResultSet resultSet;
+
+		@Test
+		void mapRow_mapsAllColumns() throws SQLException {
+			when(resultSet.getLong("InvoiceNumber")).thenReturn(137968392L);
+			when(resultSet.getLong("OcrNumber")).thenReturn(137968392L);
+			when(resultSet.wasNull()).thenReturn(false);
+			when(resultSet.getDate("InvoiceDate")).thenReturn(Date.valueOf(LocalDate.of(2019, Month.OCTOBER, 9)));
+			when(resultSet.getDate("DueDate")).thenReturn(Date.valueOf(LocalDate.of(2019, Month.OCTOBER, 29)));
+			when(resultSet.getString("InvoiceName")).thenReturn("137968392.pdf");
+			when(resultSet.getString("InvoiceType")).thenReturn("Faktura");
+			when(resultSet.getString("InvoiceDescription")).thenReturn("El");
+			when(resultSet.getString("InvoiceStatus")).thenReturn("Skickad");
+			when(resultSet.getBigDecimal("TotalAmount")).thenReturn(new BigDecimal("12060.0000"));
+			when(resultSet.getBigDecimal("AmountVatIncluded")).thenReturn(new BigDecimal("12059.99"));
+			when(resultSet.getBigDecimal("AmountVatExcluded")).thenReturn(new BigDecimal("9647.99"));
+			when(resultSet.getBigDecimal("VatEligiblaAmount")).thenReturn(new BigDecimal("9647.99"));
+			when(resultSet.getBigDecimal("Rounding")).thenReturn(new BigDecimal("0.01"));
+			when(resultSet.getBigDecimal("Vat")).thenReturn(new BigDecimal("9647.99"));
+			when(resultSet.getString("ReversedVat")).thenReturn("false");
+			when(resultSet.getString("Currency")).thenReturn("sek");
+			when(resultSet.getInt("CustomerId")).thenReturn(600606);
+			when(resultSet.getString("CustomerType")).thenReturn("Enterprise");
+			when(resultSet.getString("FacilityId")).thenReturn("735999109144630886");
+			when(resultSet.getString("OrganizationGroup")).thenReturn("stadsbacken");
+			when(resultSet.getString("Administration")).thenReturn("Sundsvall Elnät");
+			when(resultSet.getString("OrganizationId")).thenReturn("5565027223");
+			when(resultSet.getString("Street")).thenReturn("DB79B,  FE 11040");
+			when(resultSet.getString("PostalCode")).thenReturn("83882");
+			when(resultSet.getString("City")).thenReturn("FRÖSÖN");
+			when(resultSet.getString("CareOf")).thenReturn("Fräscha fastigheter AB");
+			when(resultSet.getString("PdfAvailable")).thenReturn("true");
+
+			final var entity = new InvoiceRowMapper().mapRow(resultSet, 0);
+
+			assertThat(entity.getInvoiceNumber()).isEqualTo(137968392L);
+			assertThat(entity.getOcrNumber()).isEqualTo(137968392L);
+			assertThat(entity.getInvoiceDate()).isEqualTo(LocalDate.of(2019, Month.OCTOBER, 9));
+			assertThat(entity.getDueDate()).isEqualTo(LocalDate.of(2019, Month.OCTOBER, 29));
+			assertThat(entity.getInvoiceName()).isEqualTo("137968392.pdf");
+			assertThat(entity.getInvoiceType()).isEqualTo("Faktura");
+			assertThat(entity.getInvoiceDescription()).isEqualTo("El");
+			assertThat(entity.getInvoiceStatus()).isEqualTo("Skickad");
+			assertThat(entity.getTotalAmount()).isEqualByComparingTo("12060.00");
+			assertThat(entity.getAmountVatIncluded()).isEqualByComparingTo("12059.99");
+			assertThat(entity.getAmountVatExcluded()).isEqualByComparingTo("9647.99");
+			assertThat(entity.getVatEligibleAmount()).isEqualByComparingTo("9647.99");
+			assertThat(entity.getRounding()).isEqualByComparingTo("0.01");
+			assertThat(entity.getVat()).isEqualByComparingTo("9647.99");
+			assertThat(entity.getReversedVat()).isFalse();
+			assertThat(entity.getCurrency()).isEqualTo("sek");
+			assertThat(entity.getCustomerId()).isEqualTo(600606);
+			assertThat(entity.getCustomerType()).isEqualTo("Enterprise");
+			assertThat(entity.getFacilityId()).isEqualTo("735999109144630886");
+			assertThat(entity.getOrganizationGroup()).isEqualTo("stadsbacken");
+			assertThat(entity.getAdministration()).isEqualTo("Sundsvall Elnät");
+			assertThat(entity.getOrganizationId()).isEqualTo("5565027223");
+			assertThat(entity.getStreet()).isEqualTo("DB79B,  FE 11040");
+			assertThat(entity.getPostCode()).isEqualTo("83882");
+			assertThat(entity.getCity()).isEqualTo("FRÖSÖN");
+			assertThat(entity.getCareOf()).isEqualTo("Fräscha fastigheter AB");
+			assertThat(entity.getPdfAvailable()).isTrue();
+		}
+
+		@Test
+		void mapRow_withNullOcrNumber_mapsToNull() throws SQLException {
+			when(resultSet.getLong(anyString())).thenReturn(0L);
+			when(resultSet.wasNull()).thenReturn(true);
+
+			final var entity = new InvoiceRowMapper().mapRow(resultSet, 0);
+
+			assertThat(entity.getOcrNumber()).isNull();
+		}
+
+		// The view stores the boolean flags as strings, including the literal text 'NULL'. Anything other than 'true'/'1'
+		// resolves to false, mirroring the previous Hibernate mapping (verified against the 'NULL'-valued fixture invoice).
+		@ParameterizedTest
+		@CsvSource(nullValues = "java-null", value = {
+			"true, true",
+			"TRUE, true",
+			"false, false",
+			"NULL, false",
+			"1, true",
+			"0, false",
+			"java-null, false"
+		})
+		void mapRow_parsesBooleanFlags(final String stored, final boolean expected) throws SQLException {
+			when(resultSet.getString(anyString())).thenReturn(stored);
+
+			final var entity = new InvoiceRowMapper().mapRow(resultSet, 0);
+
+			assertThat(entity.getReversedVat()).isEqualTo(expected);
+			assertThat(entity.getPdfAvailable()).isEqualTo(expected);
 		}
 	}
 }

--- a/src/test/java/se/sundsvall/datawarehousereader/integration/stadsbacken/InvoiceRepositoryTest.java
+++ b/src/test/java/se/sundsvall/datawarehousereader/integration/stadsbacken/InvoiceRepositoryTest.java
@@ -1,7 +1,5 @@
 package se.sundsvall.datawarehousereader.integration.stadsbacken;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.Month;
 import java.util.List;
@@ -12,15 +10,18 @@ import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabas
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
 import se.sundsvall.datawarehousereader.api.model.invoice.InvoiceParameters;
-import se.sundsvall.datawarehousereader.integration.stadsbacken.model.invoice.InvoiceEntity;
 
 import static java.util.Optional.ofNullable;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
 import static org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace.NONE;
 
 /**
  * invoice repository tests.
+ * <p>
+ * These tests exercise the {@code InvoiceSpecification} filtering through
+ * {@link InvoiceRepository#findDistinctInvoiceNumbers},
+ * which is the contract this repository owns. The raw row fetch (and entity column mapping) lives in
+ * {@link InvoiceJdbcRepository} and is covered by its own test.
  *
  * @see src/test/resources/db/scripts/testdata.sql for data setup.
  */
@@ -48,318 +49,76 @@ class InvoiceRepositoryTest {
 	@Test
 	void getInvoicesByAdministration() {
 
-		var invoiceNumbers = invoiceRepository.findDistinctInvoiceNumbers(createParameters("Sundsvall Energi AB ", null, null, null, null, null, null), PageRequest.of(0, 100));
-		var result = invoiceRepository.findAllByInvoiceNumberIn(invoiceNumbers.getContent());
+		var result = invoiceRepository.findDistinctInvoiceNumbers(createParameters("Sundsvall Energi AB ", null, null, null, null, null, null), PageRequest.of(0, 100));
 
-		assertThat(result)
-			.hasSize(9)
-			.extracting(
-				InvoiceEntity::getAdministration,
-				InvoiceEntity::getOrganizationId,
-				InvoiceEntity::getAmountVatExcluded,
-				InvoiceEntity::getAmountVatIncluded,
-				InvoiceEntity::getCareOf,
-				InvoiceEntity::getCity,
-				InvoiceEntity::getCurrency,
-				InvoiceEntity::getCustomerId,
-				InvoiceEntity::getCustomerType,
-				InvoiceEntity::getDueDate,
-				InvoiceEntity::getFacilityId,
-				InvoiceEntity::getInvoiceDate,
-				InvoiceEntity::getInvoiceDescription,
-				InvoiceEntity::getInvoiceName)
-			.containsExactlyInAnyOrder(
-				tuple("Sundsvall Energi AB", "5564786647", toBigDecimal(1030.06), toBigDecimal(1287.58), "Fastighetsförmedling AB", "SUNDSVALL", "sek", 10335, "Enterprise", LocalDate.of(2019, Month.NOVEMBER, 8), "735999109323726010", LocalDate.of(2019,
-					Month.OCTOBER, 9),
-					"Fjärrvärme", "138023890.pdf"),
-				tuple("Sundsvall Energi AB", "5564786647", toBigDecimal(1306.98), toBigDecimal(1633.73), "Fastighetsförmedling AB", "SUNDSVALL", "sek", 10335, "Enterprise", LocalDate.of(2019, Month.NOVEMBER, 8), "735999109324119255", LocalDate.of(2019,
-					Month.OCTOBER, 9),
-					"Fjärrvärme", "138023999.pdf"),
-				tuple("Sundsvall Energi AB", "5564786647", toBigDecimal(2652.40), toBigDecimal(3315.50), "Statlig instutition", "SUNDSVALL", "sek", 600675, "Enterprise", LocalDate.of(2019, Month.NOVEMBER, 8), "735999109111805057", LocalDate.of(2019,
-					Month.OCTOBER, 9),
-					"Fjärrvärme", "138042593.pdf"),
-				tuple("Sundsvall Energi AB", "5564786647", toBigDecimal(171.03), toBigDecimal(213.79), "Fastighetsförmedling AB", "Sundsvall", "sek", 10335, "Enterprise", LocalDate.of(2019, Month.NOVEMBER, 11), "735999109141107350", LocalDate.of(2019,
-					Month.OCTOBER, 10),
-					"Fjärrvärme", "139034094.pdf"),
-				tuple("Sundsvall Energi AB", "5564786647", toBigDecimal(543.17), toBigDecimal(678.96), "Fastighetsförmedling AB", "SUNDSVALL", "sek", 10335, "Enterprise", LocalDate.of(2019, Month.NOVEMBER, 11), "735999109141713193", LocalDate.of(2019,
-					Month.OCTOBER, 10),
-					"Fjärrvärme", "139345193.pdf"),
-				tuple("Sundsvall Energi AB", "5564786647", toBigDecimal(1937.97), toBigDecimal(2422.46), "Fastighetsförmedling AB", "SUNDSVALL", "sek", 10335, "Enterprise", LocalDate.of(2019, Month.NOVEMBER, 11), "735999109231810016", LocalDate.of(2019,
-					Month.OCTOBER,
-					10), "Fjärrvärme", "139348890.pdf"),
-				tuple("Sundsvall Energi AB", "5564786647", toBigDecimal(274.96), toBigDecimal(343.7), "Pettson Findus", "Vetlanda", "sek", 691071, "Private", LocalDate.of(2019, Month.OCTOBER, 30), "735999226000059909", LocalDate.of(2019, Month.OCTOBER, 8),
-					"Fjärrkyla",
-					"766763197.pdf"),
-				tuple("Sundsvall Energi AB", "5564786647", toBigDecimal(33.04), toBigDecimal(41.3), "Fastighetsförmedling AB", "Sundsvall", "sek", 10335, "Enterprise", LocalDate.of(2019, Month.NOVEMBER, 7), "735999109252711002", LocalDate.of(2019,
-					Month.OCTOBER, 8),
-					"Fjärrvärme", "767234891.pdf"),
-				tuple("Sundsvall Energi AB", "5564786647", toBigDecimal(135.55), toBigDecimal(169.44), "Fastighetsförmedling AB", "Sundsvall", "sek", 10335, "Enterprise", LocalDate.of(2019, Month.NOVEMBER, 7), "735999109141107350", LocalDate.of(2019,
-					Month.OCTOBER, 8),
-					"Fjärrvärme", "767891997.pdf"));
-
+		assertThat(result.getContent()).containsExactlyInAnyOrder(
+			138023890L, 138023999L, 138042593L, 139034094L, 139345193L, 139348890L, 766763197L, 767234891L, 767891997L);
 	}
 
 	@Test
 	void getInvoiceByAdministrationAndDueDateBetween() {
 
-		var invoiceNumbers = invoiceRepository.findDistinctInvoiceNumbers(createParameters("Sundsvall Energi AB ", null, LocalDate.of(2019, Month.OCTOBER, 30), LocalDate.of(2019, Month.NOVEMBER, 7), null, null, null), PageRequest.of(0, 100));
-		var result = invoiceRepository.findAllByInvoiceNumberIn(invoiceNumbers.getContent());
+		var result = invoiceRepository.findDistinctInvoiceNumbers(createParameters("Sundsvall Energi AB ", null, LocalDate.of(2019, Month.OCTOBER, 30), LocalDate.of(2019, Month.NOVEMBER, 7), null, null, null), PageRequest.of(0, 100));
 
-		assertThat(result)
-			.hasSize(3)
-			.extracting(
-				InvoiceEntity::getAdministration,
-				InvoiceEntity::getOrganizationId,
-				InvoiceEntity::getAmountVatExcluded,
-				InvoiceEntity::getAmountVatIncluded,
-				InvoiceEntity::getCareOf,
-				InvoiceEntity::getCity,
-				InvoiceEntity::getCurrency,
-				InvoiceEntity::getCustomerId,
-				InvoiceEntity::getCustomerType,
-				InvoiceEntity::getDueDate,
-				InvoiceEntity::getFacilityId,
-				InvoiceEntity::getInvoiceDate,
-				InvoiceEntity::getInvoiceDescription,
-				InvoiceEntity::getInvoiceName)
-			.containsExactlyInAnyOrder(
-				tuple("Sundsvall Energi AB", "5564786647", toBigDecimal(274.96), toBigDecimal(343.7), "Pettson Findus", "Vetlanda", "sek", 691071, "Private", LocalDate.of(2019, Month.OCTOBER, 30), "735999226000059909", LocalDate.of(2019, Month.OCTOBER, 8),
-					"Fjärrkyla",
-					"766763197.pdf"),
-				tuple("Sundsvall Energi AB", "5564786647", toBigDecimal(33.04), toBigDecimal(41.3), "Fastighetsförmedling AB", "Sundsvall", "sek", 10335, "Enterprise", LocalDate.of(2019, Month.NOVEMBER, 7), "735999109252711002", LocalDate.of(2019,
-					Month.OCTOBER, 8),
-					"Fjärrvärme", "767234891.pdf"),
-				tuple("Sundsvall Energi AB", "5564786647", toBigDecimal(135.55), toBigDecimal(169.44), "Fastighetsförmedling AB", "Sundsvall", "sek", 10335, "Enterprise", LocalDate.of(2019, Month.NOVEMBER, 7), "735999109141107350", LocalDate.of(2019,
-					Month.OCTOBER, 8),
-					"Fjärrvärme", "767891997.pdf"));
+		assertThat(result.getContent()).containsExactlyInAnyOrder(766763197L, 767234891L, 767891997L);
 	}
 
 	@Test
 	void getInvoiceByAdministrationAndDueDateLargerOrEqualThan() {
-		var invoiceNumbers = invoiceRepository.findDistinctInvoiceNumbers(createParameters("Sundsvall Energi AB ", null, LocalDate.of(2019, Month.NOVEMBER, 8), null, null, null, null), PageRequest.of(0, 100));
-		var result = invoiceRepository.findAllByInvoiceNumberIn(invoiceNumbers.getContent());
 
-		assertThat(result)
-			.hasSize(6)
-			.extracting(
-				InvoiceEntity::getAdministration,
-				InvoiceEntity::getOrganizationId,
-				InvoiceEntity::getAmountVatExcluded,
-				InvoiceEntity::getAmountVatIncluded,
-				InvoiceEntity::getCareOf,
-				InvoiceEntity::getCity,
-				InvoiceEntity::getCurrency,
-				InvoiceEntity::getCustomerId,
-				InvoiceEntity::getCustomerType,
-				InvoiceEntity::getDueDate,
-				InvoiceEntity::getFacilityId,
-				InvoiceEntity::getInvoiceDate,
-				InvoiceEntity::getInvoiceDescription,
-				InvoiceEntity::getInvoiceName)
-			.containsExactlyInAnyOrder(
-				tuple("Sundsvall Energi AB", "5564786647", toBigDecimal(1030.06), toBigDecimal(1287.58), "Fastighetsförmedling AB", "SUNDSVALL", "sek", 10335, "Enterprise", LocalDate.of(2019, Month.NOVEMBER, 8), "735999109323726010", LocalDate.of(2019,
-					Month.OCTOBER, 9),
-					"Fjärrvärme", "138023890.pdf"),
-				tuple("Sundsvall Energi AB", "5564786647", toBigDecimal(1306.98), toBigDecimal(1633.73), "Fastighetsförmedling AB", "SUNDSVALL", "sek", 10335, "Enterprise", LocalDate.of(2019, Month.NOVEMBER, 8), "735999109324119255", LocalDate.of(2019,
-					Month.OCTOBER, 9),
-					"Fjärrvärme", "138023999.pdf"),
-				tuple("Sundsvall Energi AB", "5564786647", toBigDecimal(2652.40), toBigDecimal(3315.50), "Statlig instutition", "SUNDSVALL", "sek", 600675, "Enterprise", LocalDate.of(2019, Month.NOVEMBER, 8), "735999109111805057", LocalDate.of(2019,
-					Month.OCTOBER, 9),
-					"Fjärrvärme", "138042593.pdf"),
-				tuple("Sundsvall Energi AB", "5564786647", toBigDecimal(171.03), toBigDecimal(213.79), "Fastighetsförmedling AB", "Sundsvall", "sek", 10335, "Enterprise", LocalDate.of(2019, Month.NOVEMBER, 11), "735999109141107350", LocalDate.of(2019,
-					Month.OCTOBER, 10),
-					"Fjärrvärme", "139034094.pdf"),
-				tuple("Sundsvall Energi AB", "5564786647", toBigDecimal(543.17), toBigDecimal(678.96), "Fastighetsförmedling AB", "SUNDSVALL", "sek", 10335, "Enterprise", LocalDate.of(2019, Month.NOVEMBER, 11), "735999109141713193", LocalDate.of(2019,
-					Month.OCTOBER, 10),
-					"Fjärrvärme", "139345193.pdf"),
-				tuple("Sundsvall Energi AB", "5564786647", toBigDecimal(1937.97), toBigDecimal(2422.46), "Fastighetsförmedling AB", "SUNDSVALL", "sek", 10335, "Enterprise", LocalDate.of(2019, Month.NOVEMBER, 11), "735999109231810016", LocalDate.of(2019,
-					Month.OCTOBER,
-					10), "Fjärrvärme", "139348890.pdf"));
+		var result = invoiceRepository.findDistinctInvoiceNumbers(createParameters("Sundsvall Energi AB ", null, LocalDate.of(2019, Month.NOVEMBER, 8), null, null, null, null), PageRequest.of(0, 100));
+
+		assertThat(result.getContent()).containsExactlyInAnyOrder(
+			138023890L, 138023999L, 138042593L, 139034094L, 139345193L, 139348890L);
 	}
 
 	@Test
 	void getInvoiceByCustomerId() {
-		var invoiceNumbers = invoiceRepository.findDistinctInvoiceNumbers(createParameters(null, List.of("600675"), null, null, null, null, null), PageRequest.of(0, 100));
-		var result = invoiceRepository.findAllByInvoiceNumberIn(invoiceNumbers.getContent());
 
-		assertThat(result)
-			.hasSize(1)
-			.extracting(
-				InvoiceEntity::getAdministration,
-				InvoiceEntity::getOrganizationId,
-				InvoiceEntity::getAmountVatExcluded,
-				InvoiceEntity::getAmountVatIncluded,
-				InvoiceEntity::getCareOf,
-				InvoiceEntity::getCity,
-				InvoiceEntity::getCurrency,
-				InvoiceEntity::getCustomerId,
-				InvoiceEntity::getCustomerType,
-				InvoiceEntity::getDueDate,
-				InvoiceEntity::getFacilityId,
-				InvoiceEntity::getInvoiceDate,
-				InvoiceEntity::getInvoiceDescription,
-				InvoiceEntity::getInvoiceName)
-			.containsExactlyInAnyOrder(
-				tuple("Sundsvall Energi AB", "5564786647", toBigDecimal(2652.40), toBigDecimal(3315.50), "Statlig instutition", "SUNDSVALL", "sek", 600675, "Enterprise", LocalDate.of(2019, Month.NOVEMBER, 8), "735999109111805057", LocalDate.of(2019,
-					Month.OCTOBER, 9),
-					"Fjärrvärme", "138042593.pdf"));
+		var result = invoiceRepository.findDistinctInvoiceNumbers(createParameters(null, List.of("600675"), null, null, null, null, null), PageRequest.of(0, 100));
+
+		assertThat(result.getContent()).containsExactlyInAnyOrder(138042593L);
 	}
 
 	@Test
 	void getInvoiceByMultipleCustomerIds() {
-		var invoiceNumbers = invoiceRepository.findDistinctInvoiceNumbers(createParameters(null, List.of("600675", "600606"), null, null, null, null, null), PageRequest.of(0, 100));
-		var result = invoiceRepository.findAllByInvoiceNumberIn(invoiceNumbers.getContent());
 
-		assertThat(result)
-			.hasSize(6)
-			.extracting(
-				InvoiceEntity::getAdministration,
-				InvoiceEntity::getOrganizationId,
-				InvoiceEntity::getAmountVatExcluded,
-				InvoiceEntity::getAmountVatIncluded,
-				InvoiceEntity::getCareOf,
-				InvoiceEntity::getCity,
-				InvoiceEntity::getCurrency,
-				InvoiceEntity::getCustomerId,
-				InvoiceEntity::getCustomerType,
-				InvoiceEntity::getDueDate,
-				InvoiceEntity::getFacilityId,
-				InvoiceEntity::getInvoiceDate,
-				InvoiceEntity::getInvoiceDescription,
-				InvoiceEntity::getInvoiceName)
-			.containsExactlyInAnyOrder(
-				tuple("Sundsvall Energi AB", "5564786647", toBigDecimal(2652.40), toBigDecimal(3315.50), "Statlig instutition", "SUNDSVALL", "sek", 600675, "Enterprise", LocalDate.of(2019, Month.NOVEMBER, 8), "735999109111805057", LocalDate.of(2019,
-					Month.OCTOBER, 9),
-					"Fjärrvärme", "138042593.pdf"),
-				tuple("Sundsvall Elnät", "5565027223", toBigDecimal(1085.8900), toBigDecimal(1357.3600), "Fräscha fastigheter AB", "FRÖSÖN", "sek", 600606, "Enterprise", LocalDate.of(2019, Month.OCTOBER, 29), "735999109261218707", LocalDate.of(2019,
-					Month.OCTOBER, 9),
-					"El", "137968194.pdf"),
-				tuple("Sundsvall Elnät", "5565027223", toBigDecimal(38904.8100), toBigDecimal(48631.0100), "Fräscha fastigheter AB", "FRÖSÖN", "sek", 600606, "Enterprise", LocalDate.of(2019, Month.OCTOBER, 29), "735999109140205897", LocalDate.of(2019,
-					Month.OCTOBER, 9),
-					"El", "137968293.pdf"),
-				tuple("Sundsvall Elnät", "5565027223", toBigDecimal(9647.9900), toBigDecimal(12059.9900), "Fräscha fastigheter AB", "FRÖSÖN", "sek", 600606, "Enterprise", LocalDate.of(2019, Month.OCTOBER, 29), "735999109144630886", LocalDate.of(2019,
-					Month.OCTOBER, 9),
-					"El", "137968392.pdf"),
-				tuple("Sundsvall Elnät", "5565027223", toBigDecimal(1520.0000), toBigDecimal(1900.0000), "Fräscha fastigheter AB", "FRÖSÖN", "sek", 600606, "Enterprise", LocalDate.of(2019, Month.NOVEMBER, 1), "600606", LocalDate.of(2019, Month.OCTOBER, 2),
-					"El", "765386099.pdf"),
-				tuple("Sundsvall Elnät", "5565027223", toBigDecimal(-1520.0000), toBigDecimal(-1900.0000), "Fräscha fastigheter AB", "FRÖSÖN", "sek", 600606, "Enterprise", LocalDate.of(2019, Month.OCTOBER, 31), "600606", LocalDate.of(2019, Month.OCTOBER,
-					14),
-					"El", "767916190.pdf"));
+		var result = invoiceRepository.findDistinctInvoiceNumbers(createParameters(null, List.of("600675", "600606"), null, null, null, null, null), PageRequest.of(0, 100));
+
+		assertThat(result.getContent()).containsExactlyInAnyOrder(
+			138042593L, 137968194L, 137968293L, 137968392L, 765386099L, 767916190L);
 	}
 
 	@Test
 	void getInvoiceByInvoiceNumber() {
-		var invoiceNumbers = invoiceRepository.findDistinctInvoiceNumbers(createParameters(null, null, null, null, 138023999L, null, null), PageRequest.of(0, 100));
-		var result = invoiceRepository.findAllByInvoiceNumberIn(invoiceNumbers.getContent());
 
-		assertThat(result)
-			.hasSize(1)
-			.extracting(
-				InvoiceEntity::getAdministration,
-				InvoiceEntity::getOrganizationId,
-				InvoiceEntity::getAmountVatExcluded,
-				InvoiceEntity::getAmountVatIncluded,
-				InvoiceEntity::getCareOf,
-				InvoiceEntity::getCity,
-				InvoiceEntity::getCurrency,
-				InvoiceEntity::getCustomerId,
-				InvoiceEntity::getCustomerType,
-				InvoiceEntity::getDueDate,
-				InvoiceEntity::getFacilityId,
-				InvoiceEntity::getInvoiceDate,
-				InvoiceEntity::getInvoiceDescription,
-				InvoiceEntity::getInvoiceName)
-			.containsExactlyInAnyOrder(
-				tuple("Sundsvall Energi AB", "5564786647", toBigDecimal(1306.98), toBigDecimal(1633.73), "Fastighetsförmedling AB", "SUNDSVALL", "sek", 10335, "Enterprise", LocalDate.of(2019, Month.NOVEMBER, 8), "735999109324119255", LocalDate.of(2019,
-					Month.OCTOBER, 9),
-					"Fjärrvärme", "138023999.pdf"));
+		var result = invoiceRepository.findDistinctInvoiceNumbers(createParameters(null, null, null, null, 138023999L, null, null), PageRequest.of(0, 100));
+
+		assertThat(result.getContent()).containsExactlyInAnyOrder(138023999L);
 	}
 
 	@Test
 	void getInvoiceByOcrNumber() {
-		var invoiceNumbers = invoiceRepository.findDistinctInvoiceNumbers(createParameters(null, null, null, null, null, 138023999L, null), PageRequest.of(0, 100));
-		var result = invoiceRepository.findAllByInvoiceNumberIn(invoiceNumbers.getContent());
 
-		assertThat(result)
-			.hasSize(1)
-			.extracting(
-				InvoiceEntity::getAdministration,
-				InvoiceEntity::getOrganizationId,
-				InvoiceEntity::getAmountVatExcluded,
-				InvoiceEntity::getAmountVatIncluded,
-				InvoiceEntity::getCareOf,
-				InvoiceEntity::getCity,
-				InvoiceEntity::getCurrency,
-				InvoiceEntity::getCustomerId,
-				InvoiceEntity::getCustomerType,
-				InvoiceEntity::getDueDate,
-				InvoiceEntity::getFacilityId,
-				InvoiceEntity::getInvoiceDate,
-				InvoiceEntity::getInvoiceDescription,
-				InvoiceEntity::getInvoiceName)
-			.containsExactlyInAnyOrder(
-				tuple("Sundsvall Energi AB", "5564786647", toBigDecimal(1306.98), toBigDecimal(1633.73), "Fastighetsförmedling AB", "SUNDSVALL", "sek", 10335, "Enterprise", LocalDate.of(2019, Month.NOVEMBER, 8), "735999109324119255", LocalDate.of(2019,
-					Month.OCTOBER, 9),
-					"Fjärrvärme", "138023999.pdf"));
+		var result = invoiceRepository.findDistinctInvoiceNumbers(createParameters(null, null, null, null, null, 138023999L, null), PageRequest.of(0, 100));
+
+		assertThat(result.getContent()).containsExactlyInAnyOrder(138023999L);
 	}
 
 	@Test
 	void getInvoiceByFacilityId() {
-		var invoiceNumbers = invoiceRepository.findDistinctInvoiceNumbers(createParameters(null, null, null, null, null, null, List.of("735999109324119255")), PageRequest.of(0, 100));
-		var result = invoiceRepository.findAllByInvoiceNumberIn(invoiceNumbers.getContent());
 
-		assertThat(result)
-			.hasSize(1)
-			.extracting(
-				InvoiceEntity::getAdministration,
-				InvoiceEntity::getOrganizationId,
-				InvoiceEntity::getAmountVatExcluded,
-				InvoiceEntity::getAmountVatIncluded,
-				InvoiceEntity::getCareOf,
-				InvoiceEntity::getCity,
-				InvoiceEntity::getCurrency,
-				InvoiceEntity::getCustomerId,
-				InvoiceEntity::getCustomerType,
-				InvoiceEntity::getDueDate,
-				InvoiceEntity::getFacilityId,
-				InvoiceEntity::getInvoiceDate,
-				InvoiceEntity::getInvoiceDescription,
-				InvoiceEntity::getInvoiceName)
-			.containsExactlyInAnyOrder(
-				tuple("Sundsvall Energi AB", "5564786647", toBigDecimal(1306.98), toBigDecimal(1633.73), "Fastighetsförmedling AB", "SUNDSVALL", "sek", 10335, "Enterprise", LocalDate.of(2019, Month.NOVEMBER, 8), "735999109324119255", LocalDate.of(2019,
-					Month.OCTOBER, 9),
-					"Fjärrvärme", "138023999.pdf"));
+		var result = invoiceRepository.findDistinctInvoiceNumbers(createParameters(null, null, null, null, null, null, List.of("735999109324119255")), PageRequest.of(0, 100));
+
+		assertThat(result.getContent()).containsExactlyInAnyOrder(138023999L);
 	}
 
 	@Test
 	void getInvoiceByMultipleFacilityIds() {
-		var invoiceNumbers = invoiceRepository.findDistinctInvoiceNumbers(createParameters(null, null, null, null, null, null, List.of("735999109324119255", "735999109451436027")), PageRequest.of(0, 100));
-		var result = invoiceRepository.findAllByInvoiceNumberIn(invoiceNumbers.getContent());
 
-		assertThat(result)
-			.hasSize(2)
-			.extracting(
-				InvoiceEntity::getAdministration,
-				InvoiceEntity::getOrganizationId,
-				InvoiceEntity::getAmountVatExcluded,
-				InvoiceEntity::getAmountVatIncluded,
-				InvoiceEntity::getCareOf,
-				InvoiceEntity::getCity,
-				InvoiceEntity::getCurrency,
-				InvoiceEntity::getCustomerId,
-				InvoiceEntity::getCustomerType,
-				InvoiceEntity::getDueDate,
-				InvoiceEntity::getFacilityId,
-				InvoiceEntity::getInvoiceDate,
-				InvoiceEntity::getInvoiceDescription,
-				InvoiceEntity::getInvoiceName)
-			.containsExactlyInAnyOrder(
-				tuple("Sundsvall Energi AB", "5564786647", toBigDecimal(1306.98), toBigDecimal(1633.73), "Fastighetsförmedling AB", "SUNDSVALL", "sek", 10335, "Enterprise", LocalDate.of(2019, Month.NOVEMBER, 8), "735999109324119255", LocalDate.of(2019,
-					Month.OCTOBER, 9),
-					"Fjärrvärme", "138023999.pdf"),
-				tuple("Sundsvall Elnät", "5565027223", toBigDecimal(1058.2500), toBigDecimal(1322.8100), "Fastighetsförmedling AB", "SUNDSVALL", "sek", 10335, "Enterprise", LocalDate.of(2019, Month.NOVEMBER, 11), "735999109451436027", LocalDate.of(2019,
-					Month.OCTOBER, 10),
-					"El", "139349898.pdf"));
+		var result = invoiceRepository.findDistinctInvoiceNumbers(createParameters(null, null, null, null, null, null, List.of("735999109324119255", "735999109451436027")), PageRequest.of(0, 100));
+
+		assertThat(result.getContent()).containsExactlyInAnyOrder(138023999L, 139349898L);
 	}
 
 	private static InvoiceParameters createParameters(String administration, List<String> customerNumber, LocalDate dueDateFrom, LocalDate dueDateTo, Long invoiceNumber, Long ocrNumber, List<String> facilityId) {
@@ -373,9 +132,5 @@ class InvoiceRepositoryTest {
 		ofNullable(facilityId).ifPresent(p -> parameters.setFacilityIds(facilityId));
 
 		return parameters;
-	}
-
-	private static BigDecimal toBigDecimal(double number) {
-		return BigDecimal.valueOf(number).setScale(4, RoundingMode.UP);
 	}
 }

--- a/src/test/java/se/sundsvall/datawarehousereader/service/InvoiceServiceTest.java
+++ b/src/test/java/se/sundsvall/datawarehousereader/service/InvoiceServiceTest.java
@@ -74,7 +74,7 @@ class InvoiceServiceTest {
 		final Page<Long> page = new PageImpl<>(invoiceNumbers, pageable, invoiceEntities.size());
 
 		when(invoiceRepositoryMock.findDistinctInvoiceNumbers(eq(params), any(Pageable.class))).thenReturn(page);
-		when(invoiceRepositoryMock.findAllByInvoiceNumberIn(invoiceNumbers)).thenReturn(invoiceEntities);
+		when(invoiceJdbcRepositoryMock.findAllByInvoiceNumberIn(invoiceNumbers)).thenReturn(invoiceEntities);
 
 		final var result = service.getInvoices(params);
 
@@ -108,7 +108,7 @@ class InvoiceServiceTest {
 		final Page<Long> page = new PageImpl<>(invoiceNumbers, pageable, invoiceEntities.size());
 
 		when(invoiceRepositoryMock.findDistinctInvoiceNumbers(eq(params), any(Pageable.class))).thenReturn(page);
-		when(invoiceRepositoryMock.findAllByInvoiceNumberIn(invoiceNumbers)).thenReturn(invoiceEntities);
+		when(invoiceJdbcRepositoryMock.findAllByInvoiceNumberIn(invoiceNumbers)).thenReturn(invoiceEntities);
 
 		final var result = service.getInvoices(params);
 
@@ -126,6 +126,43 @@ class InvoiceServiceTest {
 		assertThat(result.getInvoices()).hasSameElementsAs(toInvoices(Map.of(
 			1L, List.of(invoiceEntity1),
 			2L, List.of(invoiceEntity2))));
+	}
+
+	@Test
+	void getInvoices_aggregatesAllRowsPerInvoiceNumber() {
+		// The invoice view returns one row per facility/description line. Every row must contribute to the aggregated sets -
+		// regression test for the bug where only a single description/facility survived because JPA collapsed the rows.
+		final var invoiceNumber = 60027196918L;
+		final var facilityId = "735999109151605013";
+		final var invoiceNumbers = List.of(invoiceNumber);
+		final var rows = List.of(
+			invoiceRow(invoiceNumber, facilityId, "El"),
+			invoiceRow(invoiceNumber, facilityId, "Elhandel"),
+			invoiceRow(invoiceNumber, facilityId, "Elhandel produktion"),
+			invoiceRow(invoiceNumber, facilityId, "Elnät produktion"));
+		final var params = InvoiceParameters.create();
+
+		final var pageable = Pageable.ofSize(params.getLimit()).withPage(params.getPage() - 1);
+		final Page<Long> page = new PageImpl<>(invoiceNumbers, pageable, 1);
+
+		when(invoiceRepositoryMock.findDistinctInvoiceNumbers(eq(params), any(Pageable.class))).thenReturn(page);
+		when(invoiceJdbcRepositoryMock.findAllByInvoiceNumberIn(invoiceNumbers)).thenReturn(rows);
+
+		final var result = service.getInvoices(params);
+
+		assertThat(result.getInvoices()).hasSize(1);
+		final var invoice = result.getInvoices().getFirst();
+		assertThat(invoice.getInvoiceDescriptions())
+			.containsExactlyInAnyOrder("El", "Elhandel", "Elhandel produktion", "Elnät produktion");
+		assertThat(invoice.getFacilityIds()).containsExactly(facilityId);
+	}
+
+	private static InvoiceEntity invoiceRow(final long invoiceNumber, final String facilityId, final String invoiceDescription) {
+		final var entity = new InvoiceEntity();
+		entity.setInvoiceNumber(invoiceNumber);
+		entity.setFacilityId(facilityId);
+		entity.setInvoiceDescription(invoiceDescription);
+		return entity;
 	}
 
 	@Test


### PR DESCRIPTION
The invoice view returns one row per facility/description line, but InvoiceEntity's @Id is invoiceNumber alone, so Hibernate's identity map collapsed all rows of an invoice into a single entity. The Java-side aggregation in InvoiceMapper.toInvoice(List) therefore only ever saw one row, yielding a single invoiceDescription/facilityId instead of the full set.

Fetch the raw view rows through InvoiceJdbcRepository.findAllByInvoiceNumberIn (NamedParameterJdbcTemplate + InvoiceRowMapper) instead of via JPA. JDBC bypasses the persistence context, so every row survives and the mapper aggregates correctly. OPTION (RECOMPILE) preserves the previous @WithRecompile plan hint, which does not apply to plain JDBC.

Remove the buggy JPA findAllByInvoiceNumberIn; InvoiceRepository keeps findDistinctInvoiceNumbers (the Specification filter). Boolean flags are parsed from the view's string form to reproduce the prior Hibernate output.

Tests: service-level multi-row aggregation regression, RowMapper column mapping + boolean parsing, JDBC SQL/param/empty-input; InvoiceRepositoryTest refocused onto findDistinctInvoiceNumbers.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [ ] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added/updated tests to cover my changes (if applicable).
